### PR TITLE
Add playwight test cases for sidebar

### DIFF
--- a/src/components/FeaturedVideoCard/featuredVideoCard.playwright.test.ts Copied!
+++ b/src/components/FeaturedVideoCard/featuredVideoCard.playwright.test.ts Copied!
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("FeaturedVideoCard Component", () => {
+  test("should render the component with provided props", async ({ page }) => {
+    await page.goto("/videos");
+    const title = await page.locator("text='Sample Video Title'");
+    const dateTime = await page.locator("[data-testid='featured-card-date-time']");
+    const image = await page.locator("img[alt='Sample Video Title']");
+
+    await expect(title).toBeVisible();
+    await expect(dateTime).toBeVisible();
+    await expect(image).toHaveAttribute("src", "https://example.com/sample.jpg");
+  });
+
+  test("should display default image when imgUrl is not provided", async ({ page }) => {
+    await page.goto("/videos");
+    const image = await page.locator("img[alt='Sample Video Title']");
+
+    await expect(image).toHaveAttribute("src", "/assets/images/temp-youtube-logo.webp");
+  });
+
+  test("should render the organizer name", async ({ page }) => {
+    await page.goto("/your-page-with-video-card");
+    const organizerName = await page.locator("[data-testid='video-card-organizer']");
+    await expect(organizerName).toHaveText("Sample Video Organizer");
+  });
+
+  test("should not render when isVisible is false", async ({ page }) => {
+    await page.goto("/videos");
+    const videoCard = await page.locator("[data-testid='video-card']");
+    await expect(videoCard).not.toBeVisible();
+  });
+
+  test("should render correctly with different width values", async ({ page }) => {
+    await page.goto("/videos");
+    const videoCard = await page.locator("[data-testid='video-card']");
+    await expect(videoCard).toHaveCSS("width", "100%");
+  });
+
+  test("should render with empty description", async ({ page }) => {
+    await page.goto("/videos");
+    const description = await page.locator("[data-testid='video-description']");
+    await expect(description).toBeEmpty();
+  });
+
+  test("should have the correct alt text for the image", async ({ page }) => {
+    await page.goto("/videos");
+    const image = await page.locator("img[alt='Sample Video Title']");
+    await expect(image).toHaveAttribute("alt", "Sample Video Title");
+  });
+
+  test("should render empty date when date is not provided", async ({ page }) => {
+    await page.goto("/videos");
+    const date = await page.locator("[data-testid='video-card-date-time']");
+    await expect(date).toBeEmpty();
+  });
+
+  test("should render the default class name", async ({ page }) => {
+    await page.goto("/videos");
+    const videoCard = await page.locator("[data-testid='video-card']");
+    await expect(videoCard).toHaveClass(/custom-class/);
+  });
+});

--- a/src/components/FeaturedVideoCard/featuredVideoCard.test.tsx
+++ b/src/components/FeaturedVideoCard/featuredVideoCard.test.tsx
@@ -13,31 +13,62 @@ const mockProps: FeaturedVideoCardProps = {
 };
 
 describe("FeaturedVideoCard", () => {
-  test("should renders the component with provided props", () => {
+  test("should render the component with provided props", () => {
     render(<FeaturedVideoCard {...mockProps} />);
-
     expect(screen.getByText(mockProps.title)).toBeInTheDocument();
     expect(screen.getByTestId("video-card-date-time")).toBeInTheDocument();
     const imgUrl = screen.getByRole("img", { name: mockProps.title }).getAttribute("src") ?? "";
     expect(screen.getByRole("img", { name: mockProps.title })).toHaveAttribute("src", imgUrl);
   });
 
-  test("should displays default image when imgUrl is not provided", () => {
+  test("should display default image when imgUrl is not provided", () => {
     render(<FeaturedVideoCard {...mockProps} imgUrl={undefined} />);
-
     const imgUrl = screen.getByRole("img", { name: mockProps.title }).getAttribute("src") ?? "";
-
     expect(decodeURIComponent(imgUrl)).toContain("/assets/images/temp-youtube-logo.webp");
   });
 
-  test("should renders the organizer name", () => {
+  test("should render the organizer name", () => {
     render(<FeaturedVideoCard {...mockProps} />);
-    expect(screen.getByText(mockProps.title)).toBeInTheDocument();
+    expect(screen.getByText(mockProps.organizerName)).toBeInTheDocument();
     expect(screen.getByTestId("video-card-organizer")).toBeInTheDocument();
   });
 
-  test("should matches snapshot", () => {
+  test("should match snapshot", () => {
     const { asFragment } = render(<FeaturedVideoCard {...mockProps} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test("should not render when isVisible is false", () => {
+    render(<FeaturedVideoCard {...mockProps} isVisible={false} />);
+    expect(screen.queryByTestId("video-card")).toBeNull();
+  });
+
+  test("should render correctly with different width values", () => {
+    const { container } = render(<FeaturedVideoCard {...mockProps} width="200px" />);
+    const card = container.firstChild as HTMLElement;
+    expect(card).toHaveStyle("width: 200px");
+  });
+
+  test("should render with empty description", () => {
+    const mockPropsEmptyDescription = { ...mockProps, description: "" };
+    render(<FeaturedVideoCard {...mockPropsEmptyDescription} />);
+    expect(screen.getByTestId("video-description")).toBeEmptyDOMElement();
+  });
+
+  test("should have the correct alt text for the image", () => {
+    render(<FeaturedVideoCard {...mockProps} />);
+    const image = screen.getByRole("img", { name: mockProps.title });
+    expect(image).toHaveAttribute("alt", mockProps.title);
+  });
+
+  test("should render empty date when date is not provided", () => {
+    const mockPropsEmptyDate = { ...mockProps, date: "" };
+    render(<FeaturedVideoCard {...mockPropsEmptyDate} />);
+    expect(screen.getByTestId("video-card-date-time")).toHaveTextContent("");
+  });
+
+  test("should render the default class name", () => {
+    render(<FeaturedVideoCard {...mockProps} />);
+    expect(screen.getByTestId("video-card")).toHaveClass("custom-class");
   });
 });

--- a/src/components/Sidebar/sidebar.playwright.specs.ts
+++ b/src/components/Sidebar/sidebar.playwright.specs.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+import useLanguage from "@/services/i18n/use-language";
+
+test.describe("Sidebar Component", () => {
+  const language = useLanguage();
+  test("should render all sidebar items", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const sidebarItems = await page.locator("text=Sample Item 1, Sample Item 2, Sample Item 3");
+    await expect(sidebarItems).toBeVisible();
+  });
+
+  test("should highlight item as selected when clicked", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const item = await page.locator("text=Sample Item 1");
+    await item.click();
+
+    const selectedItem = await page.locator("text=Sample Item 1");
+    await expect(selectedItem).toHaveClass(/selected/);
+  });
+
+  test("should trigger sidebar toggle when an item is clicked", async ({ page }) => {
+    const toggleButton = await page.locator("[data-testid='sidebar-toggle-button']");
+    await toggleButton.click();
+
+    const sidebar = await page.locator("[data-testid='sidebar-container']");
+    await expect(sidebar).not.toBeVisible();
+  });
+
+  test("should render image with correct alt text for each sidebar item", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const image = await page.locator("img[alt='Sample Item 1']");
+    await expect(image).toBeVisible();
+    await expect(image).toHaveAttribute("alt", "Sample Item 1");
+  });
+
+  test("should render sidebar items with correct layout", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const menuStack = await page.locator("div[role='menu']");
+    const items = await menuStack.locator("li");
+    await expect(items).toHaveCount(3);
+  });
+});

--- a/src/components/Sidebar/sidebar.test.tsx
+++ b/src/components/Sidebar/sidebar.test.tsx
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+
+import useLanguage from "@/services/i18n/use-language";
+
+test.describe("Sidebar Component", () => {
+  const language = useLanguage();
+
+  const mockSidebarItems = ["Item 1", "Item 2", "Item 3"];
+
+  test("should render all sidebar items", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    for (const item of mockSidebarItems) {
+      const menuItem = await page.locator(`text=${item}`);
+      await expect(menuItem).toBeVisible();
+    }
+  });
+
+  test("should highlight item as selected when clicked", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const item1 = await page.locator("text=Item 1");
+    await item1.click();
+
+    await expect(item1).toHaveClass(/selected/);
+  });
+
+  test("should trigger sidebar toggle when an item is clicked", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const item1 = await page.locator("text=Item 1");
+    await item1.click();
+
+    const sidebarContainer = await page.locator("[data-testid='sidebar-container']");
+    await expect(sidebarContainer).toBeVisible();
+  });
+
+  test("should render image with correct alt text for each sidebar item", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    for (const item of mockSidebarItems) {
+      const image = await page.locator(`img[alt='${item}']`);
+      await expect(image).toBeVisible();
+      await expect(image).toHaveAttribute("alt", item);
+    }
+  });
+
+  test("should render sidebar items with correct layout", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const menuStack = await page.locator("[data-testid='menu-stack']");
+    const items = await menuStack.locator("li");
+    await expect(items).toHaveCount(mockSidebarItems.length);
+  });
+
+  test("should match snapshot", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+    const sidebar = await page.locator("[data-testid='sidebar-container']");
+    expect(await sidebar.screenshot()).toMatchSnapshot();
+  });
+
+  test("should handle no sidebar items gracefully", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    await page.evaluate(() => {
+      const sidebar = document.querySelector("[data-testid='sidebar-container']")!;
+      sidebar.setAttribute("data-sidebar-items", "[]");
+    });
+
+    const noItemsMessage = await page.locator("text=No items available");
+    await expect(noItemsMessage).toBeVisible();
+  });
+
+  test("should render correct item image size", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const image = await page.locator("img[alt='Item 1']");
+    const width = await image.getAttribute("width");
+    const height = await image.getAttribute("height");
+
+    await expect(width).toBe("18");
+    await expect(height).toBe("12");
+  });
+
+  test("should render default class name", async ({ page }) => {
+    await page.goto(`/${language}/videos`);
+
+    const sidebarContainer = await page.locator("[data-testid='sidebar-container']");
+    await expect(sidebarContainer).toHaveClass("custom-class");
+  });
+});


### PR DESCRIPTION
### Video Listing Page along with Select & Video Card atomic components
Link to the associated Taiga tickets: 
- [Siebar test cases](https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/89?kanban-status=262&kanban-swimlane=22)

What’s Implemented?
✅ Test cases for sidebar component

How It Works?
After logging in to the application, You will be redirected to the video listing page, and see sidebar items on left

Testing & Validation:
- [x] Test cases
