### PR TITLE
feat: add dark/light theme switch

### DIFF
--- a/src/components/Navbar/__snapshots__/navbar.test.tsx.snap
+++ b/src/components/Navbar/__snapshots__/navbar.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Navbar Component should snapshot test for Navbar 1`] = `
+exports[`Navbar Component should match snapshot 1`] = `
 <DocumentFragment>
   <header
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-1mb2kr5-MuiPaper-root-MuiAppBar-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-ptdwpq-MuiPaper-root-MuiAppBar-root"
     data-testid="navbar"
-    style="--Paper-shadow: var(--mui-shadows-4); --Paper-overlay: var(--mui-overlays-4);"
+    style="--Paper-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);"
   >
     <div
-      class="MuiContainer-root css-12f197v-MuiContainer-root"
+      class="MuiContainer-root css-12pwiy3-MuiContainer-root"
     >
       <div
         class="MuiToolbar-root MuiToolbar-regular css-1u9o2lj-MuiToolbar-root"
@@ -18,7 +18,7 @@ exports[`Navbar Component should snapshot test for Navbar 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="YouTubeIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -28,7 +28,7 @@ exports[`Navbar Component should snapshot test for Navbar 1`] = `
             />
           </svg>
           <h6
-            class="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap css-gy6dzc-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap css-1xs0nbu-MuiTypography-root"
           >
             Arbisoft Sessions Portal
           </h6>
@@ -40,22 +40,22 @@ exports[`Navbar Component should snapshot test for Navbar 1`] = `
             class="css-1yzrppa-Search-root"
           >
             <div
-              class="MuiInputBase-root MuiInputBase-colorPrimary css-1v5fh7w-MuiInputBase-root-StyledInputBase-root"
+              class="MuiInputBase-root MuiInputBase-colorPrimary css-ixlbt1-MuiInputBase-root-StyledInputBase-root"
             >
               <input
                 aria-label="search"
-                class="MuiInputBase-input css-1943rd7-MuiInputBase-input"
+                class="MuiInputBase-input css-yimnyd-MuiInputBase-input"
                 placeholder="Search..."
                 type="text"
                 value=""
               />
             </div>
             <div
-              class="css-1fwm7ty-SearchIconWrapper-root"
+              class="css-1u7x123-SearchIconWrapper-root"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="SearchIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -72,25 +72,19 @@ exports[`Navbar Component should snapshot test for Navbar 1`] = `
         >
           <button
             aria-label="Open settings"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1j2eanh-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1ty4zuc-MuiButtonBase-root-MuiIconButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
           >
             <div
-              class="MuiAvatar-root MuiAvatar-rounded MuiAvatar-colorDefault css-p5wg1c-MuiAvatar-root"
+              class="MuiAvatar-root MuiAvatar-rounded css-14h7kw6-MuiAvatar-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiAvatar-fallback css-pamvpt-MuiSvgIcon-root-MuiAvatar-fallback"
-                data-testid="PersonIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
-                />
-              </svg>
+              <img
+                alt="John Doe"
+                class="MuiAvatar-img css-1su80sj-MuiAvatar-img"
+                src="https://example.com/avatar.jpg"
+              />
             </div>
           </button>
         </div>

--- a/src/components/Navbar/navbar.test.tsx
+++ b/src/components/Navbar/navbar.test.tsx
@@ -1,57 +1,121 @@
-import { act, fireEvent, customRender as render, screen } from "@/jest/utils/testUtils";
+import { ReactElement } from "react";
+
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider, useDispatch, useSelector } from "react-redux";
+
+import { act, fireEvent, screen, waitFor, render, RenderOptions } from "@/jest/utils/testUtils";
+import { loginActions } from "@/redux/login/slice";
+import { persistor } from "@/redux/store/configureStore";
+
+import ThemeProvider from "../theme/theme-provider";
 
 import Navbar from "./navbar";
 
+// Mock Redux hooks
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"), // Preserve other exports
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+// Mock persistor
+jest.mock("@/redux/store/configureStore", () => ({
+  persistor: {
+    purge: jest.fn(),
+    persist: jest.fn(),
+  },
+}));
+
+const mockStore = configureStore({
+  reducer: {
+    // Add your reducers here
+    login: () => ({
+      userInfo: {
+        full_name: "John Doe",
+        avatar: "https://example.com/avatar.jpg",
+      },
+    }),
+  },
+});
+
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, "wrapper">) =>
+  render(ui, {
+    wrapper: ({ children }) => (
+      <Provider store={mockStore}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </Provider>
+    ),
+    ...options,
+  });
+
 describe("Navbar Component", () => {
-  test("should renders Navbar without crashing", () => {
-    render(<Navbar />);
+  const mockDispatch = jest.fn();
+  const mockUserInfo = {
+    full_name: "John Doe",
+    avatar: "https://example.com/avatar.jpg",
+  };
+
+  beforeEach(() => {
+    // Mock useSelector to return userInfo
+    (useSelector as unknown as jest.Mock).mockReturnValue(mockUserInfo);
+
+    // Mock useDispatch to return mockDispatch
+    (useDispatch as unknown as jest.Mock).mockReturnValue(mockDispatch);
+
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  test("should render Navbar without crashing", () => {
+    customRender(<Navbar />);
     expect(screen.getByTestId("navbar")).toBeInTheDocument();
   });
 
-  test("should renders the logo with YouTube icon", () => {
+  test("should render the logo with YouTube icon and text", () => {
     render(<Navbar />);
     expect(screen.getByTestId("navbar")).toBeInTheDocument();
     expect(screen.getByText("Arbisoft Sessions Portal")).toBeInTheDocument();
+    expect(screen.getByTestId("YouTubeIcon")).toBeInTheDocument();
   });
 
-  test("should renders search input", () => {
+  test("should render search input", () => {
     render(<Navbar />);
     expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
   });
 
-  test("should renders avatar button", () => {
+  test("should render avatar button", () => {
     render(<Navbar />);
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open settings/i })).toBeInTheDocument();
   });
 
-  test("should opens user menu when avatar is clicked", () => {
+  test("should open user menu when avatar is clicked", () => {
     render(<Navbar />);
-    const avatarButton = screen.getByRole("button");
+    const avatarButton = screen.getByRole("button", { name: /open settings/i });
     fireEvent.click(avatarButton);
     expect(screen.getByText("Profile")).toBeInTheDocument();
   });
 
-  test("should closes user menu when menu item is clicked", () => {
+  test("should close user menu when menu item is clicked", () => {
     render(<Navbar />);
-    const avatarButton = screen.getByRole("button");
+    const avatarButton = screen.getByRole("button", { name: /open settings/i });
     fireEvent.click(avatarButton);
     const menuItem = screen.getByText("Profile");
     fireEvent.click(menuItem);
     expect(menuItem).not.toBeVisible();
   });
 
-  test("should search input is focusable", () => {
+  test("should focus on search input when clicked", () => {
     render(<Navbar />);
     const searchInput = screen.getByPlaceholderText("Search...");
     act(() => {
       searchInput.focus();
-      expect(searchInput).toHaveFocus();
     });
+    expect(searchInput).toHaveFocus();
   });
 
-  test("should user menu contains all settings", () => {
+  test("should user menu contains all settings and logout option", () => {
     render(<Navbar />);
-    const avatarButton = screen.getByRole("button");
+    const avatarButton = screen.getByRole("button", { name: /open settings/i });
     fireEvent.click(avatarButton);
     const settings = ["Profile", "Account", "Dashboard", "Logout"];
     settings.forEach((setting) => {
@@ -59,25 +123,51 @@ describe("Navbar Component", () => {
     });
   });
 
-  test("should applies correct styles for the search box", () => {
+  test("should apply correct styles for the search box", () => {
     render(<Navbar />);
     const searchBox = screen.getByPlaceholderText("Search...");
     expect(searchBox).toHaveStyle("color: currentColor");
   });
 
-  test("should tooltip is present on avatar button", async () => {
+  test("should display tooltip on avatar button hover", async () => {
     render(<Navbar />);
-    const avatarButton = screen.getByRole("button");
+    const avatarButton = screen.getByRole("button", { name: /open settings/i });
     fireEvent.mouseOver(avatarButton);
     expect(await screen.findByText("Open settings")).toBeInTheDocument();
   });
 
-  test("should search icon is displayed", () => {
+  test("should render search icon", () => {
     render(<Navbar />);
     expect(screen.getByTestId("SearchIcon")).toBeInTheDocument();
   });
 
-  test("should snapshot test for Navbar", () => {
+  test("should call logout and purge persistor when logout is clicked", async () => {
+    render(<Navbar />);
+    const avatarButton = screen.getByRole("button", { name: /open settings/i });
+    fireEvent.click(avatarButton);
+
+    // Click the logout menu item
+    const logoutMenuItem = screen.getByText("Logout");
+    fireEvent.click(logoutMenuItem);
+
+    // Verify that logout action and persistor purge are called
+    expect(mockDispatch).toHaveBeenCalledWith(loginActions.logout());
+    expect(persistor.purge).toHaveBeenCalled();
+
+    // Wait for persistor.persist to be called
+    await waitFor(() => expect(persistor.persist).toHaveBeenCalled());
+  });
+
+  test("should render ThemeToggle in the user menu", () => {
+    render(<Navbar />);
+    const avatarButton = screen.getByRole("button", { name: /open settings/i });
+    fireEvent.click(avatarButton);
+    expect(screen.getByRole("button", { name: /light/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /system/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /dark/i })).toBeInTheDocument();
+  });
+
+  test("should match snapshot", () => {
     const { asFragment } = render(<Navbar />);
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/components/Navbar/navbar.tsx
+++ b/src/components/Navbar/navbar.tsx
@@ -18,6 +18,8 @@ import { selectUserInfo } from "@/redux/login/selectors";
 import { loginActions } from "@/redux/login/slice";
 import { persistor } from "@/redux/store/configureStore";
 
+import ThemeToggle from "../ThemeToggle";
+
 import { Logo, Search, SearchIconWrapper, StyledInputBase } from "./styled";
 
 const settings = ["Profile", "Account", "Dashboard"];
@@ -65,7 +67,7 @@ function Navbar() {
           <Box sx={{ flexGrow: 0, width: 240, display: "flex", justifyContent: "flex-end" }}>
             <Tooltip title="Open settings">
               <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                <Avatar variant="rounded" alt={userInfo.full_name ?? ""} src={userInfo.avatar ?? ""} />
+                <Avatar variant="rounded" alt={userInfo?.full_name ?? ""} src={userInfo?.avatar ?? ""} />
               </IconButton>
             </Tooltip>
             <Menu
@@ -89,6 +91,9 @@ function Navbar() {
               ))}
               <MenuItem onClick={handleLogout}>
                 <Typography>Logout</Typography>
+              </MenuItem>
+              <MenuItem disableRipple disableTouchRipple>
+                <ThemeToggle />
               </MenuItem>
             </Menu>
           </Box>

--- a/src/components/ThemeToggle/__snapshots__/themeToggle.test.tsx.snap
+++ b/src/components/ThemeToggle/__snapshots__/themeToggle.test.tsx.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ThemeToggle should snapshot test for ThemeToggle 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Basic button group"
+    class="MuiButtonGroup-root MuiButtonGroup-outlined MuiButtonGroup-horizontal MuiButtonGroup-colorPrimary css-smlsl6-MuiButtonGroup-root"
+    role="group"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlinedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlinedPrimary MuiButtonGroup-firstButton css-17cnjex-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1tjwu2m-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
+          data-testid="LightModeIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5M2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1m18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1M11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1m0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1M5.99 4.58c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41zm12.37 12.37c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0 .39-.39.39-1.03 0-1.41zm1.06-10.96c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0zM7.05 18.36c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0z"
+          />
+        </svg>
+      </span>
+      Light
+    </button>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlinedPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlinedPrimary MuiButtonGroup-middleButton css-1giegix-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1tjwu2m-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
+          data-testid="SettingsBrightnessIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2m0 16.01H3V4.99h18zM8 16h2.5l1.5 1.5 1.5-1.5H16v-2.5l1.5-1.5-1.5-1.5V8h-2.5L12 6.5 10.5 8H8v2.5L6.5 12 8 13.5zm4-7c1.66 0 3 1.34 3 3s-1.34 3-3 3z"
+          />
+        </svg>
+      </span>
+      System
+    </button>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlinedPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlinedPrimary MuiButtonGroup-lastButton css-1giegix-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1tjwu2m-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
+          data-testid="DarkModeIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+          />
+        </svg>
+      </span>
+      Dark
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/ThemeToggle/index.ts
+++ b/src/components/ThemeToggle/index.ts
@@ -1,0 +1,3 @@
+import ThemeToggle from "./themeToggle";
+
+export default ThemeToggle;

--- a/src/components/ThemeToggle/themeToggle.test.tsx
+++ b/src/components/ThemeToggle/themeToggle.test.tsx
@@ -1,0 +1,138 @@
+import { useColorScheme } from "@mui/material/styles";
+
+import { customRender as render, screen, fireEvent } from "@/jest/utils/testUtils";
+
+import ThemeToggle from "./themeToggle";
+
+jest.mock("@mui/material/styles", () => ({
+  ...jest.requireActual("@mui/material/styles"), // Preserve other exports
+  useColorScheme: jest.fn(), // Mock useColorScheme
+}));
+
+describe("ThemeToggle", () => {
+  const mockSetMode = jest.fn();
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it("renders the light mode button as active when mode is light", () => {
+    // Mock the return value of useColorScheme
+    (useColorScheme as jest.Mock).mockReturnValue({
+      mode: "light",
+      setMode: mockSetMode,
+    });
+
+    render(<ThemeToggle />);
+
+    // Check that the light mode button is active
+    const lightButton = screen.getByRole("button", { name: /light/i });
+    expect(lightButton).toHaveClass("MuiButton-contained");
+
+    // Check that the other buttons are not active
+    const systemButton = screen.getByRole("button", { name: /system/i });
+    expect(systemButton).not.toHaveClass("MuiButton-contained");
+
+    const darkButton = screen.getByRole("button", { name: /dark/i });
+    expect(darkButton).not.toHaveClass("MuiButton-contained");
+  });
+
+  it("renders the system mode button as active when mode is system", () => {
+    // Mock the return value of useColorScheme
+    (useColorScheme as jest.Mock).mockReturnValue({
+      mode: "system",
+      setMode: mockSetMode,
+    });
+
+    render(<ThemeToggle />);
+
+    // Check that the system mode button is active
+    const systemButton = screen.getByRole("button", { name: /system/i });
+    expect(systemButton).toHaveClass("MuiButton-contained");
+
+    // Check that the other buttons are not active
+    const lightButton = screen.getByRole("button", { name: /light/i });
+    expect(lightButton).not.toHaveClass("MuiButton-contained");
+
+    const darkButton = screen.getByRole("button", { name: /dark/i });
+    expect(darkButton).not.toHaveClass("MuiButton-contained");
+  });
+
+  it("renders the dark mode button as active when mode is dark", () => {
+    // Mock the return value of useColorScheme
+    (useColorScheme as jest.Mock).mockReturnValue({
+      mode: "dark",
+      setMode: mockSetMode,
+    });
+
+    render(<ThemeToggle />);
+
+    // Check that the dark mode button is active
+    const darkButton = screen.getByRole("button", { name: /dark/i });
+    expect(darkButton).toHaveClass("MuiButton-contained");
+
+    // Check that the other buttons are not active
+    const lightButton = screen.getByRole("button", { name: /light/i });
+    expect(lightButton).not.toHaveClass("MuiButton-contained");
+
+    const systemButton = screen.getByRole("button", { name: /system/i });
+    expect(systemButton).not.toHaveClass("MuiButton-contained");
+  });
+
+  it("calls setMode with 'light' when the light mode button is clicked", () => {
+    // Mock the return value of useColorScheme
+    (useColorScheme as jest.Mock).mockReturnValue({
+      mode: "system",
+      setMode: mockSetMode,
+    });
+
+    render(<ThemeToggle />);
+
+    // Simulate a click on the light mode button
+    const lightButton = screen.getByRole("button", { name: /light/i });
+    fireEvent.click(lightButton);
+
+    // Verify that setMode was called with 'light'
+    expect(mockSetMode).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setMode with 'system' when the system mode button is clicked", () => {
+    // Mock the return value of useColorScheme
+    (useColorScheme as jest.Mock).mockReturnValue({
+      mode: "dark",
+      setMode: mockSetMode,
+    });
+
+    render(<ThemeToggle />);
+
+    // Simulate a click on the system mode button
+    const systemButton = screen.getByRole("button", { name: /system/i });
+    fireEvent.click(systemButton);
+
+    // Verify that setMode was called with 'system'
+    expect(mockSetMode).toHaveBeenCalledWith("system");
+  });
+
+  it("calls setMode with 'dark' when the dark mode button is clicked", () => {
+    // Mock the return value of useColorScheme
+    (useColorScheme as jest.Mock).mockReturnValue({
+      mode: "light",
+      setMode: mockSetMode,
+    });
+
+    render(<ThemeToggle />);
+
+    // Simulate a click on the dark mode button
+    const darkButton = screen.getByRole("button", { name: /dark/i });
+    fireEvent.click(darkButton);
+
+    // Verify that setMode was called with 'dark'
+    expect(mockSetMode).toHaveBeenCalledWith("dark");
+  });
+
+  test("should snapshot test for ThemeToggle", () => {
+    const { asFragment } = render(<ThemeToggle />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/ThemeToggle/themeToggle.tsx
+++ b/src/components/ThemeToggle/themeToggle.tsx
@@ -1,0 +1,36 @@
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import SettingsBrightnessIcon from "@mui/icons-material/SettingsBrightness";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import { useColorScheme } from "@mui/material/styles";
+
+const ThemeToggle = () => {
+  const { mode, setMode } = useColorScheme();
+
+  return (
+    <>
+      <ButtonGroup size="small" variant="outlined" aria-label="Basic button group">
+        <Button
+          variant={mode === "light" ? "contained" : undefined}
+          onClick={() => setMode("light")}
+          startIcon={<LightModeIcon />}
+        >
+          Light
+        </Button>
+        <Button
+          variant={mode === "system" ? "contained" : undefined}
+          onClick={() => setMode("system")}
+          startIcon={<SettingsBrightnessIcon />}
+        >
+          System
+        </Button>
+        <Button variant={mode === "dark" ? "contained" : undefined} onClick={() => setMode("dark")} startIcon={<DarkModeIcon />}>
+          Dark
+        </Button>
+      </ButtonGroup>
+    </>
+  );
+};
+
+export default ThemeToggle;


### PR DESCRIPTION
### **Implement Dark and Light Theme Switch**  

#### **Summary:**  
This PR introduces a **theme switcher** that allows users to toggle between **Dark** and **Light** themes. The selected theme persists across sessions, ensuring a consistent user experience.  

#### **Changes Implemented:**  
- Added a theme toggle button to switch between **Dark** and **Light** modes.  
- Implemented **theme persistence** using local storage.  
- Ensured seamless integration with existing styles and UI components.  
- Applied necessary state management to track and update the theme dynamically.  

#### **Reviewers:**  
@farhan2742 @arslanather @sameeramin @wkhaliddev1

#### **Related Task:**  
🔗 [https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/100](https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/100) 🚀

#### **Screenshots:**  

https://github.com/user-attachments/assets/e0ccd01b-3b56-4f5c-8408-53072191454f
