### PR TITLE
test: set up mock server for Jest unit tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,10 +1,15 @@
 import "@testing-library/jest-dom";
 import "whatwg-fetch";
 import { cleanup } from "@testing-library/react";
-// Run cleanup after each test
-afterEach(() => {
-  cleanup();
-});
+import { enableFetchMocks } from "jest-fetch-mock";
+
+// Mock base URL
+process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:1234";
+
+enableFetchMocks();
+
+afterEach(() => cleanup());
+beforeEach(() => fetchMock.resetMocks());
 
 // @ts-ignore
 global.preloadedState = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "is-ci": "^3.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-fetch-mock": "^3.0.3",
         "prettier": "^3.2.5",
         "release-it": "^18.1.2",
         "storybook": "^8.1.10",
@@ -10335,6 +10336,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -16123,6 +16134,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -18043,6 +18065,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -19493,6 +19561,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "is-ci": "^3.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^3.2.5",
     "release-it": "^18.1.2",
     "storybook": "^8.1.10",

--- a/src/components/FeaturedVideoCard/__snapshots__/featuredVideoCard.test.tsx.snap
+++ b/src/components/FeaturedVideoCard/__snapshots__/featuredVideoCard.test.tsx.snap
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`FeaturedVideoCard should match snapshot 1`] = `
 <DocumentFragment>
   <div
@@ -18,8 +19,8 @@ exports[`FeaturedVideoCard should match snapshot 1`] = `
           decoding="async"
           height="192"
           loading="lazy"
-          src="/_next/image?url=%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75"
-          srcset="/_next/image?url=%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=384&q=75 1x, /_next/image?url=%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75 2x"
+          src="/_next/image?url=http%3A%2F%2Flocalhost%3A1234%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75"
+          srcset="/_next/image?url=http%3A%2F%2Flocalhost%3A1234%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=384&q=75 1x, /_next/image?url=http%3A%2F%2Flocalhost%3A1234%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75 2x"
           style="color: transparent;"
           width="315"
         />

--- a/src/components/Navbar/__snapshots__/navbar.test.tsx.snap
+++ b/src/components/Navbar/__snapshots__/navbar.test.tsx.snap
@@ -41,11 +41,11 @@ exports[`Navbar Component should match snapshot 1`] = `
           >
             <div
               class="MuiInputBase-root MuiInputBase-colorPrimary css-16stwic-MuiInputBase-root-StyledInputBase-root"
-              data-testid="search-query"
             >
               <input
                 aria-label="search"
                 class="MuiInputBase-input css-1943rd7-MuiInputBase-input"
+                data-testid="search-query"
                 placeholder="Search..."
                 type="text"
                 value=""

--- a/src/components/Navbar/navbar.test.tsx
+++ b/src/components/Navbar/navbar.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { useSearchParams } from "next/navigation";
 import { Provider, useDispatch, useSelector } from "react-redux";
 
-import { act, fireEvent, screen, waitFor, render, RenderOptions } from "@/jest/utils/testUtils";
+import { fireEvent, screen, waitFor, render, RenderOptions, act } from "@/jest/utils/testUtils";
 import { selectUserInfo } from "@/redux/login/selectors";
 import { loginActions } from "@/redux/login/slice";
 import { persistor } from "@/redux/store/configureStore";
@@ -110,7 +110,7 @@ describe("Navbar Component", () => {
 
   test("should focus on search input when clicked", () => {
     customRender(<Navbar />);
-    const searchInput = screen.getByPlaceholderText("Search...");
+    const searchInput = screen.getByTestId("search-query");
     act(() => {
       searchInput.focus();
     });
@@ -119,7 +119,7 @@ describe("Navbar Component", () => {
 
   test("should navigate on search submit", () => {
     customRender(<Navbar />);
-    fireEvent.submit(screen.getByPlaceholderText("Search..."));
+    fireEvent.submit(screen.getByTestId("search-query"));
     expect(mockNavigateTo).toHaveBeenCalledWith("videos", { search: "" });
   });
 
@@ -136,6 +136,23 @@ describe("Navbar Component", () => {
     customRender(<Navbar />);
     fireEvent.mouseOver(screen.getByTestId("avatar-btn"));
     expect(await screen.findByText("Open settings")).toBeInTheDocument();
+  });
+
+  test("should clear search input when cancel icon is clicked", () => {
+    customRender(<Navbar />);
+    const searchInput = screen.getByTestId("search-query");
+    fireEvent.change(searchInput, { target: { value: "Test Query" } });
+    expect(searchInput).toHaveValue("Test Query");
+    fireEvent.click(screen.getByTestId("cancelIcon"));
+    expect(searchInput).toHaveValue("");
+  });
+
+  test("should navigate on search submit", () => {
+    customRender(<Navbar />);
+    const searchInput = screen.getByTestId("search-query");
+    fireEvent.change(searchInput, { target: { value: "Test Query" } });
+    fireEvent.submit(searchInput);
+    expect(mockNavigateTo).toHaveBeenCalledWith("videos", { search: "Test Query" });
   });
 
   test("should call logout and purge persistor when logout is clicked", async () => {

--- a/src/components/Navbar/navbar.tsx
+++ b/src/components/Navbar/navbar.tsx
@@ -75,8 +75,7 @@ function Navbar() {
                 value={searchQuery}
                 onChange={(inputEvent: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(inputEvent.target.value)}
                 placeholder="Search..."
-                inputProps={{ "aria-label": "search" }}
-                data-testid="search-query"
+                inputProps={{ "aria-label": "search", "data-testid": "search-query" }}
               />
 
               {searchQuery.length > 0 && (

--- a/src/components/VideoCard/__snapshots__/videoCard.test.tsx.snap
+++ b/src/components/VideoCard/__snapshots__/videoCard.test.tsx.snap
@@ -24,8 +24,8 @@ exports[`VideoCard should matches snapshot 1`] = `
           decoding="async"
           height="192"
           loading="lazy"
-          src="/_next/image?url=%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75"
-          srcset="/_next/image?url=%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=384&q=75 1x, /_next/image?url=%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75 2x"
+          src="/_next/image?url=http%3A%2F%2Flocalhost%3A1234%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75"
+          srcset="/_next/image?url=http%3A%2F%2Flocalhost%3A1234%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=384&q=75 1x, /_next/image?url=http%3A%2F%2Flocalhost%3A1234%2Fassets%2Fimages%2Ftemp-youtube-logo.webp&w=640&q=75 2x"
           style="color: transparent;"
           width="315"
         />

--- a/src/components/containers/MainLayoutContainer/__snapshots__/mainLayoutContainer.test.tsx.snap
+++ b/src/components/containers/MainLayoutContainer/__snapshots__/mainLayoutContainer.test.tsx.snap
@@ -41,11 +41,11 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
           >
             <div
               class="MuiInputBase-root MuiInputBase-colorPrimary css-16stwic-MuiInputBase-root-StyledInputBase-root"
-              data-testid="search-query"
             >
               <input
                 aria-label="search"
                 class="MuiInputBase-input css-1943rd7-MuiInputBase-input"
+                data-testid="search-query"
                 placeholder="Search..."
                 type="text"
                 value=""

--- a/src/redux/customBaseQuery.ts
+++ b/src/redux/customBaseQuery.ts
@@ -7,12 +7,7 @@ import { selectAccessToken } from "./login/selectors";
 import { parseError } from "./parseError";
 import { ReducersState } from "./store/configureStore";
 
-let HOST_URL = (process.env.NEXT_PUBLIC_BASE_URL ?? "") + "/api/v1";
-
-if (process.env.NODE_ENV === "test") {
-  // TODO: mock test server
-  HOST_URL = "http://localhost:8000/api/v1";
-}
+const HOST_URL = (process.env.NEXT_PUBLIC_BASE_URL ?? "") + "/api/v1";
 
 interface ExtraOptions {
   showErrorToast?: boolean;

--- a/src/redux/events/events.test.tsx
+++ b/src/redux/events/events.test.tsx
@@ -1,52 +1,172 @@
-import { eventsApi } from "../events/apiSlice";
+import { renderHook, waitFor } from "@/jest/utils/testUtils";
+
+import { eventsApi, useGetEventsQuery } from "../events/apiSlice";
 import { store } from "../store/configureStore";
+import { Providers } from "../store/provider";
 
 describe("eventsApi endpoints", () => {
-  test("should fetches all events with params", async () => {
-    const result = await store.dispatch(eventsApi.endpoints.getEvents.initiate({ event_type: "", page: 1, status: "" }));
+  it("should fetch all events successfully", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        count: 123,
+        next: "http://api.example.org/accounts/?page=4",
+        previous: "http://api.example.org/accounts/?page=2",
+        results: [
+          {
+            id: 0,
+            title: "string",
+            description: "string",
+            publisher: {
+              id: 0,
+              first_name: "string",
+              last_name: "string",
+            },
+            event_time: "2025-03-12T11:05:22.534Z",
+            event_type: "SESSION",
+            status: "DRAFT",
+            workstream_id: "string",
+            is_featured: true,
+            tags: "string",
+            thumbnail: "string",
+            video_duration: "string",
+          },
+        ],
+      })
+    );
 
-    expect(result).toEqual({
-      status: "uninitialized",
-      isUninitialized: true,
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
+    const { result } = renderHook(() => useGetEventsQuery({ event_type: "", page: 1, status: "" }), {
+      wrapper: ({ children }) => <Providers>{children}</Providers>,
+    });
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        count: 123,
+        next: "http://api.example.org/accounts/?page=4",
+        previous: "http://api.example.org/accounts/?page=2",
+        results: [
+          {
+            id: 0,
+            title: "string",
+            description: "string",
+            publisher: {
+              id: 0,
+              first_name: "string",
+              last_name: "string",
+            },
+            event_time: "2025-03-12T11:05:22.534Z",
+            event_type: "SESSION",
+            status: "DRAFT",
+            workstream_id: "string",
+            is_featured: true,
+            tags: "string",
+            thumbnail: "string",
+            video_duration: "string",
+          },
+        ],
+      });
+      expect(result.current.isSuccess).toBe(true);
     });
   });
 
-  test("should fetches event types", async () => {
+  it("should fetch event types successfully", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify([
+        {
+          label: "SESSION",
+          key: "session",
+        },
+      ])
+    );
+
     const result = await store.dispatch(eventsApi.endpoints.eventTypes.initiate());
 
-    expect(result).toEqual({
-      status: "uninitialized",
-      isUninitialized: true,
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
-    });
+    expect(result.data).toEqual([
+      {
+        label: "SESSION",
+        key: "session",
+      },
+    ]);
+    expect(result.isSuccess).toBe(true);
   });
 
-  test("should fetches event detail", async () => {
+  it("should fetch event detail successfully", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        title: "string",
+        video_file: "string",
+        duration: 2147483647,
+        thumbnail: "string",
+        status: "PROCESSING",
+        file_size: 9223372036854776000,
+        event: {
+          id: 0,
+          title: "string",
+          description: "string",
+          publisher: {
+            id: 0,
+            first_name: "string",
+            last_name: "string",
+          },
+          event_time: "2025-03-12T11:07:29.656Z",
+          event_type: "SESSION",
+          status: "DRAFT",
+          workstream_id: "string",
+          is_featured: true,
+          tags: "string",
+          thumbnail: "string",
+          video_duration: "string",
+        },
+      }),
+      { status: 200 }
+    );
+
     const result = await store.dispatch(eventsApi.endpoints.eventDetail.initiate(1));
 
-    expect(result).toEqual({
-      status: "uninitialized",
-      isUninitialized: true,
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
+    expect(result.data).toEqual({
+      title: "string",
+      video_file: "string",
+      duration: 2147483647,
+      thumbnail: "string",
+      status: "PROCESSING",
+      file_size: 9223372036854776000,
+      event: {
+        id: 0,
+        title: "string",
+        description: "string",
+        publisher: {
+          id: 0,
+          first_name: "string",
+          last_name: "string",
+        },
+        event_time: "2025-03-12T11:07:29.656Z",
+        event_type: "SESSION",
+        status: "DRAFT",
+        workstream_id: "string",
+        is_featured: true,
+        tags: "string",
+        thumbnail: "string",
+        video_duration: "string",
+      },
     });
+    expect(result.isSuccess).toBe(true);
   });
 
-  test("should fetches event tags", async () => {
+  it("should fetch event tags successfully", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify([
+        {
+          id: 0,
+          name: "string",
+        },
+      ]),
+      { status: 200 }
+    );
     const result = await store.dispatch(eventsApi.endpoints.eventTags.initiate());
-
-    expect(result).toEqual({
-      status: "uninitialized",
-      isUninitialized: true,
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
-    });
+    expect(result.data).toEqual([
+      {
+        id: 0,
+        name: "string",
+      },
+    ]);
+    expect(result.isSuccess).toBe(true);
   });
 });

--- a/src/redux/login/login.test.tsx
+++ b/src/redux/login/login.test.tsx
@@ -1,7 +1,11 @@
+import { act, renderHook } from "@/jest/utils/testUtils";
+
 import { eventsApi } from "../events/apiSlice";
-import { loginApi } from "../login/apiSlice";
-import loginReducer, { loginActions } from "../login/slice";
 import { store } from "../store/configureStore";
+import { Providers } from "../store/provider";
+
+import { useLoginMutation } from "./apiSlice";
+import loginReducer, { loginActions } from "./slice";
 
 describe("Login API and Slice", () => {
   it("should return the initial state", () => {
@@ -57,24 +61,103 @@ describe("Login API and Slice", () => {
     expect(loginReducer(initialState, loginActions.logout())).toEqual(expectedState);
   });
 
-  it("should login failed", async () => {
-    const result = await store.dispatch(loginApi.endpoints.login.initiate({ auth_token: "test-token" }));
+  it("should login successfully", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        refresh: "eyJ0eXAiOiJKV1QiLCJhbGc...",
+        access: "eyJ0eXAiOiJKV1QiLCJhbGc...",
+        user_info: {
+          full_name: "John Doe",
+          first_name: "John",
+          last_name: "Doe",
+          avatar: "https://lh3.googleusercontent.com/a/photo",
+        },
+      }),
+      { status: 200 }
+    );
+    const { result } = renderHook(() => useLoginMutation(), {
+      wrapper: ({ children }) => <Providers>{children}</Providers>,
+    });
 
-    expect(result.error).toEqual({
-      status: 401,
-      data: {
-        detail: "Given token not valid for any token type",
-        code: "token_not_valid",
-        messages: [
-          {
-            message: "Token is invalid or expired",
-            token_class: "AccessToken",
-            token_type: "access",
-          },
-        ],
-      },
+    const [login] = result.current;
+
+    const credentials = { auth_token: "test-token" };
+
+    await act(async () => {
+      const response = await login(credentials).unwrap();
+
+      expect(response).toEqual({
+        refresh: "eyJ0eXAiOiJKV1QiLCJhbGc...",
+        access: "eyJ0eXAiOiJKV1QiLCJhbGc...",
+        user_info: {
+          full_name: "John Doe",
+          first_name: "John",
+          last_name: "Doe",
+          avatar: "https://lh3.googleusercontent.com/a/photo",
+        },
+      });
     });
   });
+
+  it("should handle login failure", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        detail: "Invalid credentials",
+      }),
+      { status: 401 } // Simulate a 401 Unauthorized error
+    );
+
+    const { result } = renderHook(() => useLoginMutation(), {
+      wrapper: ({ children }) => <Providers>{children}</Providers>,
+    });
+
+    const [login] = result.current;
+
+    const credentials = { auth_token: "invalid-token" };
+
+    await act(async () => {
+      try {
+        await login(credentials).unwrap();
+      } catch (error) {
+        expect(error).toEqual({
+          status: 401,
+          data: { detail: "Invalid credentials" },
+        });
+      }
+    });
+  });
+
+  it("should handle login timeout", async () => {
+    // Mock a fetch response that never resolves (simulating a timeout)
+    fetchMock.mockResponseOnce(
+      () =>
+        new Promise(
+          (resolve) => setTimeout(() => resolve({ body: "{}" }), 10000) // Simulate a 10-second delay
+        )
+    );
+
+    const { result } = renderHook(() => useLoginMutation(), {
+      wrapper: ({ children }) => <Providers>{children}</Providers>,
+    });
+
+    const [login] = result.current;
+
+    const credentials = { auth_token: "test-token" };
+
+    await act(async () => {
+      try {
+        await Promise.race([
+          login(credentials).unwrap(),
+          new Promise(
+            (_, reject) => setTimeout(() => reject(new Error("Request timed out")), 5000) // Simulate a 5-second timeout
+          ),
+        ]);
+      } catch (error) {
+        // @ts-ignore
+        expect(error.message).toBe("Request timed out");
+      }
+    });
+  }, 10000);
 
   it("should handle 401 response by logging out", async () => {
     const initialState = {

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,77 @@
+import { parseNonPassedParams } from "./utils";
+
+describe("parseNonPassedParams", () => {
+  test("should remove empty strings and empty arrays but keep false values", () => {
+    const input = {
+      name: "John",
+      age: 30,
+      active: false,
+      emptyString: "",
+      emptyArray: [],
+      validArray: [1, 2, 3],
+      validString: "Hello",
+    };
+
+    const expectedOutput = {
+      name: "John",
+      age: 30,
+      active: false,
+      validArray: [1, 2, 3],
+      validString: "Hello",
+    };
+
+    expect(parseNonPassedParams(input)).toEqual(expectedOutput);
+  });
+
+  test("should remove null and undefined values", () => {
+    const input = {
+      key1: null,
+      key2: undefined,
+      key3: "Valid",
+      key4: 0,
+      key5: false,
+    };
+
+    const expectedOutput = {
+      key3: "Valid",
+      key4: 0,
+      key5: false,
+    };
+
+    expect(parseNonPassedParams(input)).toEqual(expectedOutput);
+  });
+
+  test("should keep boolean false values but remove empty strings and arrays", () => {
+    const input = {
+      foo: "",
+      bar: [],
+      baz: false,
+    };
+
+    const expectedOutput = {
+      baz: false,
+    };
+
+    expect(parseNonPassedParams(input)).toEqual(expectedOutput);
+  });
+
+  test("should keep numbers and truthy values", () => {
+    const input = {
+      a: 0,
+      b: 1,
+      c: "hello",
+      d: "",
+      e: [],
+      f: [1, 2, 3],
+    };
+
+    const expectedOutput = {
+      a: 0,
+      b: 1,
+      c: "hello",
+      f: [1, 2, 3],
+    };
+
+    expect(parseNonPassedParams(input)).toEqual(expectedOutput);
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -25,16 +25,12 @@ export const convertSecondsToFormattedTime = (seconds: number): string => {
 };
 
 export function parseNonPassedParams<T extends Record<string, unknown>>(data: T): Record<string, unknown> {
-  return Object.entries(data)
-    .filter(([, value]) => {
-      let hasLength = true;
-      if (typeof value === "string" || Array.isArray(value)) {
-        hasLength = value.length !== 0;
-      }
-      return value === false || (!!value && hasLength);
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => {
+      if (value === false) return true;
+      if (typeof value === "number") return true;
+      if (typeof value === "string" || Array.isArray(value)) return value.length > 0;
+      return Boolean(value);
     })
-    .reduce((acc: Record<string, unknown>, [key, value]) => {
-      acc[key] = value;
-      return acc;
-    }, {});
+  );
 }


### PR DESCRIPTION
### **GitHub Pull Request Description**  

### **Test: Set Up Mock Server for Jest Unit Tests**  

#### **Summary:**  
This PR sets up a **mock server** for Jest unit tests, ensuring API calls are properly tested in an isolated environment.  

#### **Changes Implemented:**  
- **Integrated `jest-fetch-mock`** to mock API responses in tests.  
- **Ensured tests no longer rely on live API calls**, improving reliability and performance.  
- **Updated existing test cases** to use the mock server.  

#### **Testing & Verification:**  
- Verified API calls return **mocked responses** during tests.  
- Ensured tests **run consistently without external dependencies**.  
- Checked that the mock server correctly intercepts requests and returns expected responses.  

#### **Reviewers:**  
@farhan2742 @arslanather @sameeramin @wkhaliddev1 

#### **Related Task:**  
🔗 [Taiga Task #133](https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/133) 🚀