### PR TITLE
refactor: remove left sidebar from video detail page

### DIFF
--- a/src/components/containers/MainLayoutContainer/mainLayoutContainer.tsx
+++ b/src/components/containers/MainLayoutContainer/mainLayoutContainer.tsx
@@ -10,19 +10,22 @@ import { MainContainer, LeftSidebar, RightSidebar, ContentContainer } from "./st
 
 type TMainLayoutContainer = {
   children: React.ReactNode;
+  isLeftSidebarVisible?: boolean;
   rightSidebar?: ReactNode;
 };
 
-const MainLayoutContainer = ({ children, rightSidebar }: TMainLayoutContainer) => {
+const MainLayoutContainer = ({ children, rightSidebar, isLeftSidebarVisible = true }: TMainLayoutContainer) => {
   useAuth();
 
   return (
     <>
       <Navbar />
       <MainContainer maxWidth="xl">
-        <LeftSidebar data-testid="left-sidebar">
-          <Sidebar />
-        </LeftSidebar>
+        {isLeftSidebarVisible && (
+          <LeftSidebar data-testid="left-sidebar">
+            <Sidebar />
+          </LeftSidebar>
+        )}
         <ContentContainer container>{children}</ContentContainer>
         {isValidElement(rightSidebar) && (
           <RightSidebar sx={{ display: { xs: "none", md: "block" } }} data-testid="right-sidebar">

--- a/src/features/VideoDetail/videoDetail.tsx
+++ b/src/features/VideoDetail/videoDetail.tsx
@@ -55,6 +55,7 @@ const VideoDetail = () => {
 
   return (
     <MainLayoutContainer
+      isLeftSidebarVisible={false}
       rightSidebar={
         <div>
           <TagsContainer>


### PR DESCRIPTION
### **GitHub Pull Request Description**  

### **Fix: Remove Left Sidebar from Video Detail Page**  

#### **Summary:**  
This PR removes the **left sidebar** from the **video detail page** to provide a cleaner and more focused user experience.  

#### **Changes Implemented:**  
- **Removed the left sidebar component** from the video detail page layout.  
- **Updated styling** to adjust content width accordingly.  

#### **Testing & Verification:**  
- Verified that the **sidebar is no longer visible** on the video detail page.  
- Checked that the **content layout adjusts correctly** without breaking responsiveness.  
- Ensured no regressions or UI misalignment issues occurred.  

#### **Reviewers:**  
@farhan2742 @arslanather @sameeramin 

#### **Related Task:**  
🔗 [Taiga Task #135](https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/135) 🚀