### PR TITLE
fix: limit video title to extend up to rating

### DIFF
--- a/src/features/VideoDetail/styled.tsx
+++ b/src/features/VideoDetail/styled.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import { chipClasses } from "@mui/material/Chip";
-import { ratingClasses } from "@mui/material/Rating";
-import { styled, css } from "@mui/material/styles";
+import { styled, css, alpha } from "@mui/material/styles";
 
 export const StyledTitleSection = styled(Box, {
   name: "StyledTitleSection",
@@ -15,16 +14,7 @@ export const StyledTitleSection = styled(Box, {
 
     h4 {
       color: ${theme.palette.colors.white};
-      font-size: 20px;
-      font-style: normal;
-      font-weight: 500;
-      line-height: 26px;
       text-transform: capitalize;
-      width: 50%;
-    }
-
-    .${ratingClasses.iconFilled} {
-      color: ${theme.palette.colors.gold};
     }
   `
 );
@@ -65,7 +55,7 @@ export const StyledNotesSection = styled(Box, {
     }
 
     .description {
-      background: #ffffff26;
+      background: ${alpha(theme.palette.common.white, 0.15)};
       border-radius: 12px;
       gap: 10px;
       margin-top: ${theme.spacing(2)};
@@ -93,11 +83,11 @@ export const TagsContainer = styled(Box, {
 
     .${chipClasses.root} {
       border-radius: 6px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
+      border: 1px solid ${alpha(theme.palette.common.white, 0.3)};
 
       &.${chipClasses.filled} {
         background: ${theme.palette.colors.white};
-        color: rgba(0, 0, 0, 0.7);
+        color: ${alpha(theme.palette.common.black, 0.7)};
       }
 
       .${chipClasses.icon} {

--- a/src/features/VideoDetail/videoDetail.tsx
+++ b/src/features/VideoDetail/videoDetail.tsx
@@ -3,10 +3,8 @@ import { useEffect } from "react";
 
 import { faker } from "@faker-js/faker";
 import ArrowForward from "@mui/icons-material/ArrowForward";
-import StarIcon from "@mui/icons-material/Star";
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
-import Rating from "@mui/material/Rating";
 import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 import { skipToken } from "@reduxjs/toolkit/query";
@@ -107,7 +105,6 @@ const VideoDetail = () => {
           />
           <StyledTitleSection>
             <Typography variant="h4">{data?.title}</Typography>
-            <Rating readOnly value={3} size="medium" emptyIcon={<StarIcon fontSize="inherit" />} />
           </StyledTitleSection>
           <StyledDetailSection>
             {name && <Typography variant="h6">{name}</Typography>}


### PR DESCRIPTION
### **GitHub Pull Request Description**  

### **Fix: Remove Rating from Video Detail & Expand Video Title Width**  

#### **Summary:**  
This PR updates the **video detail page** by removing the **rating section** and allowing the **video title to take the maximum possible width**, improving readability and UI clarity.  

#### **Changes Implemented:**  
- **Removed the rating section** from the video detail page.  
- **Updated video title styling** to allow it to expand across available space.  
- **Ensured proper alignment** of the remaining elements after removal.  

#### **Reviewers:**  
@farhan2742 @arslanather @sameeramin 

#### **Related Task:**  
🔗 [Taiga Task #120](https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/120) 🚀