### PR TITLE
refactor: convert font sizes from px to rem across app

### DIFF
--- a/src/components/Navbar/__snapshots__/navbar.test.tsx.snap
+++ b/src/components/Navbar/__snapshots__/navbar.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Navbar Component should match snapshot 1`] = `
         class="MuiToolbar-root MuiToolbar-regular css-1u9o2lj-MuiToolbar-root"
       >
         <div
-          class="css-12uvfj0-Logo-root"
+          class="css-1j69kd3-Logo-root"
           data-testid="navbar-logo"
         >
           <svg
@@ -29,7 +29,7 @@ exports[`Navbar Component should match snapshot 1`] = `
             />
           </svg>
           <h6
-            class="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap css-1c6flzx-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap css-qcz5nl-MuiTypography-root"
           >
             Arbisoft Sessions Portal
           </h6>

--- a/src/components/Navbar/styled.tsx
+++ b/src/components/Navbar/styled.tsx
@@ -3,6 +3,8 @@ import InputBase, { inputBaseClasses } from "@mui/material/InputBase";
 import { alpha, css, styled } from "@mui/material/styles";
 import { typographyClasses } from "@mui/material/Typography";
 
+import { pxToRem } from "@/utils/styleUtils";
+
 export const Logo = styled("div", { name: "Logo" })(({ theme }) => {
   return css`
     align-items: center;
@@ -21,7 +23,7 @@ export const Logo = styled("div", { name: "Logo" })(({ theme }) => {
 
     .${typographyClasses.h6} {
       color: ${theme.palette.common.white};
-      font-size: 16px;
+      font-size: ${pxToRem(16)};
       font-style: normal;
       font-weight: 700;
       line-height: normal;

--- a/src/components/ReadMore/__snapshots__/readMore.test.tsx.snap
+++ b/src/components/ReadMore/__snapshots__/readMore.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ReadMore Component should match snapshot 1`] = `
 <DocumentFragment>
   <p
-    class="MuiTypography-root MuiTypography-bodySmall css-1vt6mdr-MuiTypography-root-Logo-root"
+    class="MuiTypography-root MuiTypography-bodySmall css-1ccyiev-MuiTypography-root-Logo-root"
   >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum
     <span>

--- a/src/components/ReadMore/styled.tsx
+++ b/src/components/ReadMore/styled.tsx
@@ -1,6 +1,8 @@
 import { css, styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 
+import { pxToRem } from "@/utils/styleUtils";
+
 export const StyledReadMore = styled(Typography, { name: "Logo" })(() => {
   return css`
     white-space: pre-line;
@@ -11,7 +13,7 @@ export const StyledReadMore = styled(Typography, { name: "Logo" })(() => {
     .show-more-button {
       cursor: pointer;
       display: block;
-      font-size: 14px;
+      font-size: ${pxToRem(14)};
       margin-top: 10px;
       text-decoration: underline;
       text-transform: capitalize;

--- a/src/components/Select/__snapshots__/select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/select.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Select Component should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="MuiBox-root css-199rwdr-SelectWrapper-root"
+    class="MuiBox-root css-94eo9s-SelectWrapper-root"
   >
     <label
       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-1qpm3yf-MuiFormLabel-root-MuiInputLabel-root"

--- a/src/components/Select/styled.tsx
+++ b/src/components/Select/styled.tsx
@@ -2,6 +2,8 @@ import Box from "@mui/material/Box";
 import { selectClasses } from "@mui/material/Select";
 import { styled, css, alpha } from "@mui/material/styles";
 
+import { pxToRem } from "@/utils/styleUtils";
+
 export const SelectWrapper = styled(Box, {
   name: "SelectWrapper",
 })(
@@ -13,7 +15,7 @@ export const SelectWrapper = styled(Box, {
 
     .${selectClasses.select} {
       background-color: ${alpha(theme.palette.colors.white, 0.2)};
-      font-size: 14px;
+      font-size: ${pxToRem(14)};
       font-weight: 600;
     }
   `

--- a/src/components/Sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/Sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Sidebar Component should match snapshot 1`] = `
             width="18"
           />
           <p
-            class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+            class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
           >
             All
           </p>
@@ -47,7 +47,7 @@ exports[`Sidebar Component should match snapshot 1`] = `
             width="18"
           />
           <p
-            class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+            class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
           >
             Test-1
           </p>
@@ -67,7 +67,7 @@ exports[`Sidebar Component should match snapshot 1`] = `
             width="18"
           />
           <p
-            class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+            class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
           >
             Test-2
           </p>
@@ -87,7 +87,7 @@ exports[`Sidebar Component should match snapshot 1`] = `
             width="18"
           />
           <p
-            class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+            class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
           >
             Test-3
           </p>

--- a/src/components/Sidebar/styled.tsx
+++ b/src/components/Sidebar/styled.tsx
@@ -4,7 +4,7 @@ import Stack from "@mui/material/Stack";
 import { styled, css, alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 
-import { shouldForwardProp } from "@/utils/styleUtils";
+import { pxToRem, shouldForwardProp } from "@/utils/styleUtils";
 
 export const SidebarContainer = styled(Box, {
   name: "SidebarContainer",
@@ -49,7 +49,7 @@ export const Text = styled(Typography, {
   name: "Text",
 })(() => {
   return css`
-    font-size: 14px;
+    font-size: ${pxToRem(14)};
     line-height: 12px;
     font-weight: 500;
     letter-spacing: 0.4px;

--- a/src/components/VideoCard/__snapshots__/videoCard.test.tsx.snap
+++ b/src/components/VideoCard/__snapshots__/videoCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VideoCard should matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root custom-class normal-card css-1i7dbb8-MuiPaper-root-MuiCard-root-VideoCardContainer-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root custom-class normal-card css-1yhvm1c-MuiPaper-root-MuiCard-root-VideoCardContainer-root"
     data-testid="video-card"
     style="--Paper-shadow: var(--mui-shadows-1); --Paper-overlay: var(--mui-overlays-1);"
   >
@@ -11,7 +11,7 @@ exports[`VideoCard should matches snapshot 1`] = `
       class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
     >
       <div
-        class="image-wrapper MuiBox-root css-mddgh6-ImageWrapper-root"
+        class="image-wrapper MuiBox-root css-6judcc-ImageWrapper-root"
       >
         <span
           class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-wave css-116i1gn-MuiSkeleton-root"
@@ -25,7 +25,7 @@ exports[`VideoCard should matches snapshot 1`] = `
           width="315"
         />
         <div
-          class="MuiTypography-root MuiTypography-bodyMedium video-duration css-149i8z5-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-bodyMedium video-duration css-sj15px-MuiTypography-root"
           data-testid="video-card-duration"
         >
           30:30
@@ -35,20 +35,20 @@ exports[`VideoCard should matches snapshot 1`] = `
         class="video-detail MuiBox-root css-0"
       >
         <h3
-          class="MuiTypography-root MuiTypography-h3 css-1fho9p8-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h3 css-mfh4if-MuiTypography-root"
           data-testid="video-card-title"
           title="Refresher & AMA Session on Competency Framework Changes - January 2025"
         >
           Refresher & AMA Session on Competency Framework Changes - January 2025
         </h3>
         <p
-          class="MuiTypography-root MuiTypography-bodyMedium organizer-name css-149i8z5-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-bodyMedium organizer-name css-sj15px-MuiTypography-root"
           data-testid="video-card-organizer"
         >
           John Doe
         </p>
         <p
-          class="MuiTypography-root MuiTypography-bodyMedium date-time css-149i8z5-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-bodyMedium date-time css-sj15px-MuiTypography-root"
           data-testid="video-card-date-time"
         >
           Jan 09, 2025

--- a/src/components/VideoCard/styled.tsx
+++ b/src/components/VideoCard/styled.tsx
@@ -5,7 +5,7 @@ import { skeletonClasses } from "@mui/material/Skeleton";
 import { styled, css, alpha } from "@mui/material/styles";
 import { typographyClasses } from "@mui/material/Typography";
 
-import { shouldForwardProp } from "@/utils/styleUtils";
+import { pxToRem, shouldForwardProp } from "@/utils/styleUtils";
 
 export const VideoCardContainer = styled(Card, {
   name: "VideoCardContainer",
@@ -67,7 +67,7 @@ export const VideoCardContainer = styled(Card, {
         .date-time,
         .organizer-name {
           color: ${theme.palette.colors.gray};
-          font-size: 14px;
+          font-size: ${pxToRem(14)};
           font-weight: 500;
         }
 
@@ -76,7 +76,7 @@ export const VideoCardContainer = styled(Card, {
           -webkit-line-clamp: 4;
           color: ${theme.palette.colors.white};
           display: -webkit-box;
-          font-size: 18px;
+          font-size: ${pxToRem(18)};
           font-weight: 500;
           overflow: hidden;
 
@@ -91,7 +91,7 @@ export const VideoCardContainer = styled(Card, {
       .${cardContentClasses.root} {
         .video-detail {
           .${typographyClasses.h3} {
-            font-size: 16px;
+            font-size: ${pxToRem(16)};
             font-weight: 600;
           }
         }
@@ -133,14 +133,14 @@ export const VideoCardContainer = styled(Card, {
           width: calc(100% - 113px);
 
           .${typographyClasses.h5} {
-            font-size: 12px;
+            font-size: ${pxToRem(12)};
             font-weight: 500;
           }
 
           .organizer-name,
           .date-time {
             color: ${theme.palette.colors.gray};
-            font-size: 12px;
+            font-size: ${pxToRem(12)};
           }
         }
       }
@@ -204,7 +204,7 @@ export const VideoCardContainer = styled(Card, {
 
           .organizer-name,
           .date-time {
-            font-size: 18px;
+            font-size: ${pxToRem(18)};
           }
         }
       }
@@ -263,7 +263,7 @@ export const VideoCardContainer = styled(Card, {
 
           .organizer-name,
           .date-time {
-            font-size: 18px;
+            font-size: ${pxToRem(18)};
           }
         }
       }
@@ -306,7 +306,7 @@ export const ImageWrapper = styled(Box, {
       border-radius: 2px;
       bottom: 10px;
       color: ${theme.palette.colors.white};
-      font-size: 12px;
+      font-size: ${pxToRem(12)};
       padding: 2px 4px;
       position: absolute;
       right: 10px;

--- a/src/components/containers/MainLayoutContainer/__snapshots__/mainLayoutContainer.test.tsx.snap
+++ b/src/components/containers/MainLayoutContainer/__snapshots__/mainLayoutContainer.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
         class="MuiToolbar-root MuiToolbar-regular css-1u9o2lj-MuiToolbar-root"
       >
         <div
-          class="css-12uvfj0-Logo-root"
+          class="css-1j69kd3-Logo-root"
           data-testid="navbar-logo"
         >
           <svg
@@ -29,7 +29,7 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
             />
           </svg>
           <h6
-            class="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap css-1c6flzx-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap css-qcz5nl-MuiTypography-root"
           >
             Arbisoft Sessions Portal
           </h6>
@@ -148,7 +148,7 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
                 width="18"
               />
               <p
-                class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+                class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
               >
                 All
               </p>
@@ -168,7 +168,7 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
                 width="18"
               />
               <p
-                class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+                class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
               >
                 Test-1
               </p>
@@ -188,7 +188,7 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
                 width="18"
               />
               <p
-                class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+                class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
               >
                 Test-2
               </p>
@@ -208,7 +208,7 @@ exports[`MainLayoutContainer should matches snapshot for UI consistency 1`] = `
                 width="18"
               />
               <p
-                class="MuiTypography-root MuiTypography-bodyMedium css-rudw3m-MuiTypography-root-Text-root"
+                class="MuiTypography-root MuiTypography-bodyMedium css-2u8xl4-MuiTypography-root-Text-root"
               >
                 Test-3
               </p>

--- a/src/components/theme/theme-provider.tsx
+++ b/src/components/theme/theme-provider.tsx
@@ -3,8 +3,17 @@
 import { useMemo, PropsWithChildren } from "react";
 
 import GlobalStyles from "@mui/material/GlobalStyles";
-import { createTheme, ThemeProvider as MuiThemeProvider, Shadows, Theme, useTheme } from "@mui/material/styles";
+import {
+  createTheme,
+  ThemeProvider as MuiThemeProvider,
+  responsiveFontSizes,
+  Shadows,
+  Theme,
+  useTheme,
+} from "@mui/material/styles";
 import { Roboto_Condensed, Inter } from "next/font/google";
+
+import { pxToRem } from "@/utils/styleUtils";
 
 import { colors } from "./colors";
 
@@ -40,40 +49,42 @@ function ThemeProvider(props: PropsWithChildren<{ customTheme?: Theme }>) {
   const defaultTheme = useTheme();
   const theme = useMemo(
     () =>
-      createTheme({
-        cssVariables: {
-          colorSchemeSelector: "class",
-        },
-        shadows: [...defaultTheme.shadows].map(() => "none") as Shadows,
-        palette: {
-          mode: "dark",
-          colors,
-        },
-        typography: {
-          fontFamily: fontFamily,
-          h1: { fontSize: 28, lineHeight: "normal" },
-          h2: { fontSize: 24, lineHeight: "normal" },
-          h3: { fontSize: 22, lineHeight: "normal" },
-          h4: { fontSize: 20, lineHeight: "normal" },
-          h5: { fontSize: 16, lineHeight: "normal" },
-          h6: { fontSize: 12, lineHeight: "normal" },
-          bodySmall: { ...defaultTheme.typography.body1, fontSize: 12, lineHeight: "normal", fontFamily },
-          bodyMedium: { ...defaultTheme.typography.body1, fontSize: 14, lineHeight: "normal", fontFamily },
-          bodyLarge: { ...defaultTheme.typography.body1, fontSize: 16, lineHeight: "normal", fontFamily },
-        },
-        components: {
-          MuiTypography: {
-            defaultProps: {
-              variant: "bodyMedium",
-              variantMapping: {
-                bodySmall: "p",
-                bodyMedium: "p",
-                bodyLarge: "p",
+      responsiveFontSizes(
+        createTheme({
+          cssVariables: {
+            colorSchemeSelector: "class",
+          },
+          shadows: [...defaultTheme.shadows].map(() => "none") as Shadows,
+          palette: {
+            mode: "dark",
+            colors,
+          },
+          typography: {
+            fontFamily: fontFamily,
+            h1: { fontSize: pxToRem(28) },
+            h2: { fontSize: pxToRem(24) },
+            h3: { fontSize: pxToRem(22) },
+            h4: { fontSize: pxToRem(20) },
+            h5: { fontSize: pxToRem(16) },
+            h6: { fontSize: pxToRem(12) },
+            bodySmall: { ...defaultTheme.typography.body1, fontSize: pxToRem(12), fontFamily },
+            bodyMedium: { ...defaultTheme.typography.body1, fontSize: pxToRem(14), fontFamily },
+            bodyLarge: { ...defaultTheme.typography.body1, fontSize: pxToRem(16), fontFamily },
+          },
+          components: {
+            MuiTypography: {
+              defaultProps: {
+                variant: "bodyMedium",
+                variantMapping: {
+                  bodySmall: "p",
+                  bodyMedium: "p",
+                  bodyLarge: "p",
+                },
               },
             },
           },
-        },
-      }),
+        })
+      ),
     [defaultTheme.shadows]
   );
 

--- a/src/features/SearchResultsPage/styled.tsx
+++ b/src/features/SearchResultsPage/styled.tsx
@@ -3,6 +3,8 @@ import { stackClasses } from "@mui/material/Stack";
 import { styled, css } from "@mui/material/styles";
 import { typographyClasses } from "@mui/material/Typography";
 
+import { pxToRem } from "@/utils/styleUtils";
+
 export const SearchResultsContainer = styled("div", {
   name: "SearchResultsContainer",
 })(
@@ -27,12 +29,12 @@ export const FilterBox = styled(Box, {
 
       .${typographyClasses.h2} {
         color: ${theme.palette.colors.white};
-        font-size: 24px;
+        font-size: ${pxToRem(24)};
         font-weight: 500;
         text-transform: capitalize;
 
         ${theme.breakpoints.down("sm")} {
-          font-size: 20px;
+          font-size: ${pxToRem(20)};
           width: 50%;
         }
       }
@@ -61,7 +63,7 @@ export const NoSearchResultsWrapper = styled("div", {
 
     .${typographyClasses.h3} {
       color: ${theme.palette.colors.white};
-      font-size: 24px;
+      font-size: ${pxToRem(24)};
       font-style: normal;
       font-weight: 400;
       letter-spacing: 0.4px;

--- a/src/features/VideoDetail/styled.tsx
+++ b/src/features/VideoDetail/styled.tsx
@@ -2,6 +2,8 @@ import Box from "@mui/material/Box";
 import { chipClasses } from "@mui/material/Chip";
 import { styled, css, alpha } from "@mui/material/styles";
 
+import { pxToRem } from "@/utils/styleUtils";
+
 export const StyledTitleSection = styled(Box, {
   name: "StyledTitleSection",
 })(
@@ -29,7 +31,7 @@ export const StyledDetailSection = styled(Box, {
     h6,
     p {
       color: ${theme.palette.colors.gray};
-      font-size: 16px;
+      font-size: ${pxToRem(16)};
       font-style: normal;
       font-weight: 500;
       line-height: normal;
@@ -47,7 +49,7 @@ export const StyledNotesSection = styled(Box, {
 
     h5 {
       color: ${theme.palette.colors.white};
-      font-size: 22px;
+      font-size: ${pxToRem(22)};
       font-style: normal;
       font-weight: 400;
       line-height: normal;
@@ -63,11 +65,10 @@ export const StyledNotesSection = styled(Box, {
 
       p {
         color: ${theme.palette.colors.white};
-        font-size: 12px;
+        font-size: ${pxToRem(12)};
         font-style: normal;
         font-weight: 400;
         line-height: normal;
-        text-transform: capitalize;
       }
     }
   `

--- a/src/features/VideosListingPage/styled.tsx
+++ b/src/features/VideosListingPage/styled.tsx
@@ -4,6 +4,8 @@ import { stackClasses } from "@mui/material/Stack";
 import { styled, css, alpha } from "@mui/material/styles";
 import { typographyClasses } from "@mui/material/Typography";
 
+import { pxToRem } from "@/utils/styleUtils";
+
 export const VideoListingContainer = styled("div", {
   name: "VideoListingContainer",
 })(
@@ -33,7 +35,7 @@ export const FilterBox = styled(Box, {
 
       .${typographyClasses.h2} {
         color: ${theme.palette.colors.white};
-        font-size: 24px;
+        font-size: ${pxToRem(24)};
         font-weight: 500;
         text-transform: capitalize;
       }
@@ -49,7 +51,7 @@ export const NoSearchResultsWrapper = styled("div", {
 
     .${typographyClasses.h3} {
       color: ${theme.palette.colors.white};
-      font-size: 24px;
+      font-size: ${pxToRem(24)};
       font-style: normal;
       font-weight: 400;
       letter-spacing: 0.4px;
@@ -72,7 +74,7 @@ export const DropdownContainer = styled(Box, {
       background-color: ${alpha(theme.palette.colors.white, 0.2)};
       border-color: ${alpha(theme.palette.colors.white, 0.3)};
       color: ${theme.palette.common.white};
-      font-size: 14px;
+      font-size: ${pxToRem(14)};
       font-weight: 600;
 
       &:hover {

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -1,1 +1,5 @@
 export const shouldForwardProp = (propName: string) => !propName.startsWith("$");
+
+export const pxToRem = (px: number, base = 16): string => {
+  return `${px / base}rem`;
+};


### PR DESCRIPTION
### **GitHub Pull Request Description**

---

### **refactor: Convert Font Sizes from px to rem Across the App**

---

#### **Summary:**

Replaced all hardcoded `px` font sizes with `rem` units across the app for better scalability, accessibility, and consistency with modern responsive design practices.

---

#### **Changes Implemented:**

* 🔁 Updated all typography (headings, body text, labels, buttons) from `px` to `rem`.
* 📐 Based on a root font size of `16px`, ensuring consistent conversion (`1rem = 16px`).
* 🎯 Affected components include:

  * Global styles and theme files
  * Typography components and styled elements
  * Reusable UI components (e.g., Button, Card, Modal)

---

#### **Benefits:**

* ♿ Improved accessibility through user-controlled scaling
* 📱 Better responsive behavior across screen sizes
* 🔧 Easier theming and maintenance of font sizing

---

#### **Reviewer:**

@farhan2742 @ahmad-arbisoft 

---

#### **Related Task:**

🔗 [Taiga Task](https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/179)

