### PR TITLE
fix: resolve unexpected api call to page 1

### DIFF
--- a/src/features/VideosListingPage/videosListingPage.tsx
+++ b/src/features/VideosListingPage/videosListingPage.tsx
@@ -216,7 +216,6 @@ const VideosListingPage = () => {
                 if (!isFetching && videoListings?.next && currentPlaylist === queryParams.playlist) setPage((prev) => prev + 1);
                 else {
                   setCurrentPlaylist(queryParams.playlist || "");
-                  setPage(1);
                 }
               }}
               increaseViewportBy={0}


### PR DESCRIPTION
### **🚀 Description**
Removed unexpected API call to page 1 after reaching the end of video listings.

#### **📌 Summary**
This PR resolves an issue where, after loading all available video pages, the app incorrectly triggered another API call to page 1 and displayed its content again.

#### **🔧 Changes Implemented**
- ✅ Removed setPage(1) from the fallback block
- ✅ Prevented looping back to page 1 after the last page is fetched

#### **🛠️ How It Works?**
1. Previously, when scrolling reached the end (e.g., page 13), setPage(1) was resetting the pagination and re-triggering the API.
2. That line is now removed, no more page 1 calls after full content is loaded.

#### **✅ Checklist Before Merging**
- Scrolled through all video listings
- Confirmed no extra API call to page 1
- [ ] _Ensured code follows best practices and security standards._

#### **📸 Screenshots (if applicable)**
N/A

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/212

#### **📢 Notes for Reviewers**
To reproduce:
Go to video listing
Scroll to the end (after page 13)
Confirm no API call is made to page=1 and no content reset occurs.
