### PR TITLE
refactor: restructure video listing with useVideoQueryManager hook to fix scroll and filtering issues

### DIFF
--- a/src/components/Sidebar/sidebar.tsx
+++ b/src/components/Sidebar/sidebar.tsx
@@ -11,7 +11,6 @@ import { useSearchParams } from "next/navigation";
 
 import useNavigation from "@/hooks/useNavigation";
 import useSidebar from "@/hooks/useSidebar";
-import { runsOnServerSide } from "@/services/runs-on-server-side/runs-on-server-side";
 
 import { StyledMenuItem, MenuStack, SidebarContainer, TagsContainer, Text } from "./styled";
 
@@ -27,10 +26,6 @@ const Sidebar = () => {
 
   const tag = searchParams?.get("tag");
   const playlist = searchParams?.get("playlist");
-
-  const onResetFilters = () => {
-    if (!runsOnServerSide) window.dispatchEvent(new Event("reset-filter"));
-  };
 
   return (
     <SidebarContainer data-testid="sidebar-container">
@@ -57,7 +52,6 @@ const Sidebar = () => {
                 key={item.id}
                 selected={item.name === playlist}
                 onClick={() => {
-                  onResetFilters();
                   navigateTo("videos", { playlist: item.name });
                 }}
                 data-testid={`sidebar-item-${item.name}`}
@@ -74,7 +68,6 @@ const Sidebar = () => {
               data-testid={`sidebar-tags-${item.name}`}
               key={item.id}
               onClick={() => {
-                onResetFilters();
                 navigateTo("videos", { tag: item.name });
               }}
               label={`#${item.name}`}

--- a/src/features/VideosListingPage/skeletonLoader.tsx
+++ b/src/features/VideosListingPage/skeletonLoader.tsx
@@ -1,0 +1,25 @@
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
+
+import { VideoListingContainer } from "./styled";
+import { SkeletonLoaderProps } from "./types";
+
+const SkeletonLoader = ({ count = 5 }: SkeletonLoaderProps) => {
+  const loaderCards = Array.from({ length: count });
+
+  return (
+    <VideoListingContainer>
+      <Box className="skeleton-loader">
+        {loaderCards.map((_, index) => (
+          <Box key={index} sx={{ mb: 2 }}>
+            <Skeleton width="100%" height={192} variant="rounded" animation="wave" />
+            <Skeleton width="50%" height={30} />
+            <Skeleton width="30%" height={30} />
+          </Box>
+        ))}
+      </Box>
+    </VideoListingContainer>
+  );
+};
+
+export default SkeletonLoader;

--- a/src/features/VideosListingPage/types.ts
+++ b/src/features/VideosListingPage/types.ts
@@ -35,3 +35,7 @@ export type TVideo = {
 export interface ISearchEventDetail {
   searchQuery: string;
 }
+
+export type SkeletonLoaderProps = {
+  count?: number;
+};

--- a/src/hooks/useVideoQueryManager.ts
+++ b/src/hooks/useVideoQueryManager.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { startOfYear, endOfYear, format } from "date-fns";
+
+import { defaultParams } from "@/features/VideosListingPage/types";
+import { EventsParams } from "@/models/Events";
+import { parseNonPassedParams } from "@/utils/utils";
+
+export function useVideoQueryManager(searchParams: URLSearchParams) {
+  const [page, setPage] = useState(1);
+
+  const parsedParams = useMemo(
+    () => ({
+      tag: searchParams.get("tag") || null,
+      playlist: searchParams.get("playlist") || null,
+      search: searchParams.get("search") || null,
+      order: searchParams.get("order") || null,
+      year: searchParams.get("year") || null,
+    }),
+    [searchParams]
+  );
+
+  useEffect(() => {
+    setPage(1);
+  }, [parsedParams.tag, parsedParams.playlist, parsedParams.search, parsedParams.order, parsedParams.year]);
+
+  const apiParams = useMemo(() => {
+    return parseNonPassedParams({
+      ...defaultParams,
+      page,
+      page_size: 12,
+      is_featured: false,
+      ordering: [parsedParams.order],
+      search: parsedParams.search ?? undefined,
+      tag: parsedParams.search ? "" : (parsedParams.tag ?? ""),
+      playlist: parsedParams.search ? "" : (parsedParams.playlist ?? ""),
+      event_time_after: parsedParams.year ? format(startOfYear(new Date(parsedParams.year)), "yyyy-MM-dd") : undefined,
+      event_time_before: parsedParams.year ? format(endOfYear(new Date(parsedParams.year)), "yyyy-MM-dd") : undefined,
+    }) as EventsParams;
+  }, [page, parsedParams]);
+
+  return {
+    page,
+    setPage,
+    parsedParams,
+    apiParams,
+  };
+}


### PR DESCRIPTION
### **🚀 Description**
Refactored video listing architecture to introduce a new hook `useVideoQueryManager` that centralizes query param management, page control, and API parameters. This eliminates race conditions and stale data UI bugs.

#### **📌 Summary**
This PR resolves major video listing issues related to stale data, incorrect pagination, and unwanted API calls.  
The new structure is cleaner, scalable, and easier to maintain for future enhancements.

#### **🔧 Changes Implemented**
- ✅ Introduced `useVideoQueryManager` hook
- ✅ Reset `videoData` for page 1 before new API calls to prevent stale renders
- ✅ Debounced API call on query param change
- ✅ SkeletonLoader separate component
- ✅ Controlled page reset using query param dependencies
- ✅ Separated featured section logic.

#### **🛠️ How It Works?**
1. A new custom hook useVideoQueryManager manages all query param logic in one place. with these responsibilities:
- Parses current search parameters into normalized values
- Resets the page to 1 only when meaningful params (e.g., tag, playlist, year) change
- Provides a clean apiParams object that is safe to use in the API call
2. The main component (VideosListingPage) focuses solely on rendering logic and UI state, making the architecture more modular and testable.
3. videoData is now controlled via local state, so old results for page 1 are cleared before new ones load, avoiding flicker.
4. Skeleton loading behavior is made consistent and immediate across all query transitions.

#### **✅ Checklist Before Merging**
- [x] Scrolled through all video listings
- [x] Switched between tags/playlists multiple times
- [x] Confirmed no stale content flashes
- [x] Verified no API call to page=1 when scrolling ends
- [x] Ensured featured video section hides when filtered
- [x] Code follows best practices and is testable

#### **📸 Screenshots (if applicable)**
N/A

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/226
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/212
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/issue/227
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/issue/225
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/issue/223


#### **📢 Notes for Reviewers**
1. Go to videos listing page
2. Apply tag or playlist filter
3. Scroll to last available page
4. Switch filters again, confirm correct reset
5. Confirm no API loop or unexpected flash of old videos
