### PR TITLE
feat: integrate pagination with infinite scroll for recommendations

### DIFF
--- a/src/features/VideoDetail/videoDetail.tsx
+++ b/src/features/VideoDetail/videoDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect } from "react";
+
+import { useEffect, useState } from "react";
 
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
@@ -9,6 +10,7 @@ import { skipToken } from "@reduxjs/toolkit/query";
 import { format } from "date-fns";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { Virtuoso } from "react-virtuoso";
 
 import MainLayoutContainer from "@/components/containers/MainLayoutContainer";
 import ReadMore from "@/components/ReadMore";
@@ -26,17 +28,15 @@ const VideoDetail = () => {
 
   const { navigateTo, getPageUrl } = useNavigation();
 
+  const [page, setPage] = useState(1);
+
+  const { data: recommendationsData, isFetching: isRecommendationsFetching } = useRecommendationQuery(
+    videoId ? { id: videoId, page } : skipToken
+  );
+
   const { data, isFetching, isLoading, isUninitialized, error } = useEventDetailQuery(videoId || skipToken);
 
-  const {
-    data: recommendations = [],
-    isFetching: isRecommendationsFetching,
-    isLoading: isRecommendationsLoading,
-    isUninitialized: isRecommendationsUninitialized,
-  } = useRecommendationQuery(videoId || skipToken);
-
   const isDataLoading = isFetching || isLoading || isUninitialized;
-  const areRecommendationsLoading = isRecommendationsFetching || isRecommendationsLoading || isRecommendationsUninitialized;
 
   useEffect(() => {
     document.title = `${data?.event?.title ?? ""}  - Sessions Portal`;
@@ -49,24 +49,21 @@ const VideoDetail = () => {
   }, [error]);
 
   const dataEvent = data?.event;
+  const allRecommendations = recommendationsData?.results ?? [];
 
   return (
     <MainLayoutContainer
       isLeftSidebarVisible={false}
       shouldShowDrawer
       rightSidebar={
-        <div>
-          {areRecommendationsLoading ? (
-            <Box display="flex" gap={2} flexDirection="column">
-              {Array(10)
-                .fill("")
-                .map((_, key) => (
-                  <Skeleton variant="rounded" width="100%" height={90} key={`skeleton-${key}`} />
-                ))}
-            </Box>
-          ) : (
-            recommendations.map((video) => (
+        <Box pr={1}>
+          <Virtuoso
+            data={allRecommendations}
+            useWindowScroll
+            itemContent={(_, video) => (
               <VideoCard
+                height="100px"
+                key={`recommendation-${video.id}`}
                 data={{
                   event_time: format(new Date(video.event_time), "MMM dd, yyyy"),
                   organizer: video.presenters.map(fullName).join(", "),
@@ -75,13 +72,27 @@ const VideoDetail = () => {
                   video_duration: convertSecondsToFormattedTime(video.video_duration),
                   video_file: video.video_file ? BASE_URL.concat(video.video_file) : undefined,
                 }}
-                key={`recommendation-${video.id}`}
                 onClick={() => navigateTo("videoDetail", { id: video.slug })}
                 variant="related-card"
               />
-            ))
-          )}
-        </div>
+            )}
+            endReached={() => {
+              if (!isRecommendationsFetching && recommendationsData?.next) {
+                setPage((prev) => prev + 1);
+              }
+            }}
+            components={{
+              Footer: () =>
+                isRecommendationsFetching ? (
+                  <Box mt={2} sx={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+                    {Array.from({ length: 3 }).map((_, idx) => (
+                      <Skeleton key={idx} variant="rounded" width="100%" height={90} />
+                    ))}
+                  </Box>
+                ) : null,
+            }}
+          />
+        </Box>
       }
     >
       {error || isDataLoading ? (
@@ -120,9 +131,9 @@ const VideoDetail = () => {
             <Typography variant="h5">Session Details</Typography>
             <div className="description">
               <ReadMore text={dataEvent?.description ?? ""} showLessText="Show Less" showMoreText="Show More" />
-              {(data.event?.tags?.length ?? 0) > 0 && (
+              {(dataEvent?.tags?.length ?? 0) > 0 && (
                 <TagsContainer>
-                  {data.event?.tags?.map((tag) => (
+                  {dataEvent?.tags?.map((tag) => (
                     <Chip
                       component={Link}
                       href={getPageUrl("videos", { tag })}

--- a/src/models/Events/events.ts
+++ b/src/models/Events/events.ts
@@ -34,8 +34,6 @@ export interface Event {
   slug: string;
 }
 
-export interface Recommendation extends Event {}
-
 interface Publisher {
   first_name: string;
   id: number;
@@ -76,4 +74,12 @@ export type EventsParams = {
   status: "DRAFT" | "PUBLISHED" | "ARCHIVED";
   tag?: string;
   linked_to_events?: "True" | "False";
+};
+
+export interface Recommendation extends AllEventResponse {}
+
+export type RecommendationParam = {
+  id: string;
+  page: number;
+  page_size?: number;
 };

--- a/src/redux/events/apiSlice.ts
+++ b/src/redux/events/apiSlice.ts
@@ -1,6 +1,6 @@
 import isEqual from "lodash/isEqual";
 
-import { EventDetail, Tag, AllEventResponse, EventsParams, Recommendation, Playlist } from "@/models/Events";
+import { EventDetail, Tag, AllEventResponse, EventsParams, Recommendation, Playlist, RecommendationParam } from "@/models/Events";
 import { baseApi } from "@/redux/baseApi";
 
 export const eventsApi = baseApi.injectEndpoints({
@@ -54,11 +54,26 @@ export const eventsApi = baseApi.injectEndpoints({
         method: "GET",
       }),
     }),
-    recommendation: builder.query<Recommendation[], string>({
-      query: (id) => ({
+    recommendation: builder.query<Recommendation, RecommendationParam>({
+      query: ({ id, page = 1, page_size = 10 }) => ({
         url: `/events/recommendations/${id}/`,
         method: "GET",
+        params: { page, page_size },
       }),
+      serializeQueryArgs: ({ endpointName, queryArgs }) => `${endpointName}-${queryArgs.id}`,
+      merge: (currentCache, newItems) => {
+        currentCache.count = newItems.count;
+        currentCache.previous = newItems.previous;
+        currentCache.next = newItems.next;
+
+        const existingIds = new Set(currentCache.results.map((event) => event.id));
+        const uniqueResults = newItems.results.filter((event) => !existingIds.has(event.id));
+
+        currentCache.results.push(...uniqueResults);
+      },
+      forceRefetch({ currentArg, previousArg }) {
+        return !isEqual(currentArg, previousArg);
+      },
     }),
     playlists: builder.query<Playlist[], void>({
       query: () => ({

--- a/src/redux/events/events.test.tsx
+++ b/src/redux/events/events.test.tsx
@@ -271,7 +271,7 @@ describe("eventsApi endpoints", () => {
       ])
     );
 
-    const { result } = renderHook(() => useRecommendationQuery("test-event"), {
+    const { result } = renderHook(() => useRecommendationQuery({ id: "test-event", page: 1 }), {
       wrapper: ({ children }) => <Providers>{children}</Providers>,
     });
     await waitFor(() => {
@@ -306,6 +306,91 @@ describe("eventsApi endpoints", () => {
       ]);
       expect(result.current.isSuccess).toBe(true);
     });
+  });
+
+  it("should merge paginated results and deduplicate recommendation videos", async () => {
+    const page1Response = {
+      count: 123,
+      next: "http://api.example.org/recommendation/?page=2",
+      previous: null,
+      results: [
+        {
+          id: 1,
+          title: "Event 1",
+          description: "Description 1",
+          publisher: { id: 1, first_name: "John", last_name: "Doe" },
+          event_time: "2025-03-12T11:05:22.534Z",
+          event_type: "SESSION",
+          status: "PUBLISHED",
+          workstream_id: null,
+          is_featured: false,
+          tags: ["Competency"],
+          thumbnail: "/media/thumbnails/screenshot-7c8c5c09-218d-46c2-9f7c-ed4e91c2d7fb.png",
+          video_duration: 3351,
+          presenters: [
+            {
+              id: 1,
+              first_name: "Qaisar ",
+              last_name: "Irfan",
+              email: "qaisar.irfan@arbisoft.com",
+            },
+            {
+              id: 2,
+              first_name: "Shaheer",
+              last_name: "Alam",
+              email: "shaheer.alam@arbisoft.com",
+            },
+          ],
+          playlists: ["Competency"],
+        },
+      ],
+    };
+
+    const page2Response = {
+      count: 123,
+      next: null,
+      previous: "http://api.example.org/recommendation/?page=1",
+      results: [
+        {
+          id: 2,
+          title: "Event 2",
+          description: "Description 2",
+          publisher: { id: 2, first_name: "Jane", last_name: "Smith" },
+          event_time: "2025-03-13T11:05:22.534Z",
+          event_type: "SESSION",
+          status: "PUBLISHED",
+          workstream_id: null,
+          is_featured: false,
+          tags: ["Competency"],
+          thumbnail: "/media/thumbnails/screenshot-7c8c5c09-218d-46c2-9f7c-ed4e91c2d7fb.png",
+          video_duration: 3351,
+          presenters: [
+            {
+              id: 1,
+              first_name: "Shaheer",
+              last_name: "Alam",
+              email: "shaheer.alam@arbisoft.com",
+            },
+          ],
+          playlists: ["Competency"],
+        },
+      ],
+    };
+
+    fetchMock.mockResponseOnce(JSON.stringify(page1Response));
+    fetchMock.mockResponseOnce(JSON.stringify(page2Response));
+
+    const { result, rerender } = renderHook(({ page }) => useRecommendationQuery({ id: "1", page, page_size: 12 }), {
+      wrapper: ({ children }) => <Providers>{children}</Providers>,
+      initialProps: { page: 1 },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.results.length).toBe(1);
+
+    rerender({ page: 2 });
+
+    await waitFor(() => expect(result.current.data?.results.length).toBe(2));
   });
 
   it("should fetch playlist successfully", async () => {


### PR DESCRIPTION
### **🚀 Description**
Added pagination support for recommendations API and implemented infinite scroll on the video detail page to lazyload videos.

#### **📌 Summary**
This PR improves the recommendations section on the video detail page by adding backend pagination support in the API slice and implementing infinite scroll on the frontend to load videos as the user scrolls.


#### **🔧 Changes Implemented**
- ✅ Integrated pagination parameters (page, page_size) into the recommendation endpoint in apiSlice.
- ✅ Implemented infinite scroll using react-virtuoso on the video detail page.

#### **🛠️ How It Works?**
1. The recommendation endpoint now accepts id, page, and page_size to paginate results from the backend.
2. On the frontend, react-virtuoso handles fetching new pages as the user scrolls, appending them to the list dynamically.

#### **✅ Checklist Before Merging**
-  Tested all relevant functionalities.
- Verified expected behavior on different use cases.

#### **📸 Screenshots (if applicable)**
N/A

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/231

#### **📢 Notes for Reviewers**
Ensure the recommendation list scrolls seamlessly and new pages are fetched correctly.
