### PR TITLE
test: add e2e tests for VideoDetail component with Playwright

### DIFF
--- a/playwright-tests/setup/login.spec.ts
+++ b/playwright-tests/setup/login.spec.ts
@@ -1,0 +1,7 @@
+import { test as setup } from "@playwright/test";
+
+setup("Login and save state", async ({ page }) => {
+  await page.goto("/login");
+  await page.waitForURL("**/videos");
+  await page.context().storageState({ path: "playwright-tests/storageState.json" });
+});

--- a/playwright-tests/videoDetail.spec.ts
+++ b/playwright-tests/videoDetail.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Video Detail Page", () => {
+  test("should display video title after data loads", async ({ page }) => {
+    await page.goto("/videos/all-hands-2024");
+    await expect(page.getByRole("heading", { level: 4 })).toBeVisible();
+  });
+
+  test("should render video player", async ({ page }) => {
+    await page.goto("/videos/all-hands-2024");
+    await expect(page.locator("video")).toBeVisible();
+  });
+
+  test("should show recommendations list in sidebar", async ({ page }) => {
+    await page.goto("/videos/all-hands-2024");
+    await expect(page.locator("[data-testid='recommendation-card']")).toBeVisible();
+  });
+
+  test("should show skeleton loader on initial load", async ({ page }) => {
+    await page.goto("/videos/all-hands-2024");
+    await expect(page.locator("[data-testid='video-player-skeleton']")).toBeVisible();
+  });
+
+  test("should change document title based on video title", async ({ page }) => {
+    await page.goto("/videos/all-hands-2024");
+    await expect(page).toHaveTitle(/- Sessions Portal/);
+  });
+
+  test("should navigate back to videos if error occurs", async ({ page }) => {
+    await page.goto("/videos/invalid-event-id");
+    await expect(page).toHaveURL(/\/videos$/);
+  });
+});

--- a/src/features/VideoDetail/skeletonLoader.tsx
+++ b/src/features/VideoDetail/skeletonLoader.tsx
@@ -1,0 +1,16 @@
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
+
+const SkeletonLoader = () => (
+  <div data-testid="video-player-skeleton">
+    <Skeleton width="100%" height={400} variant="rounded" animation="wave" />
+    <Box display="flex" justifyContent="space-between" width="100%">
+      <Skeleton width="50%" height={70} />
+      <Skeleton width="30%" height={70} />
+    </Box>
+    <Skeleton width="30%" height={50} />
+    <Skeleton width="100%" height={200} />
+  </div>
+);
+
+export default SkeletonLoader;

--- a/src/features/VideoDetail/videoDetail.tsx
+++ b/src/features/VideoDetail/videoDetail.tsx
@@ -21,6 +21,7 @@ import useNavigation from "@/hooks/useNavigation";
 import { useEventDetailQuery, useRecommendationQuery } from "@/redux/events/apiSlice";
 import { convertSecondsToFormattedTime, fullName } from "@/utils/utils";
 
+import SkeletonLoader from "./skeletonLoader";
 import { StyledDetailSection, StyledNotesSection, StyledTitleSection, TagsContainer } from "./styled";
 
 const VideoDetail = () => {
@@ -56,7 +57,7 @@ const VideoDetail = () => {
       isLeftSidebarVisible={false}
       shouldShowDrawer
       rightSidebar={
-        <Box pr={1}>
+        <Box pr={1} data-testid="recommendation-card">
           <Virtuoso
             data={allRecommendations}
             useWindowScroll
@@ -96,15 +97,7 @@ const VideoDetail = () => {
       }
     >
       {error || isDataLoading ? (
-        <>
-          <Skeleton width="100%" height={400} variant="rounded" animation="wave" />
-          <Box display="flex" justifyContent="space-between" width="100%">
-            <Skeleton width="50%" height={70} />
-            <Skeleton width="30%" height={70} />
-          </Box>
-          <Skeleton width="30%" height={50} />
-          <Skeleton width="100%" height={200} />
-        </>
+        <SkeletonLoader />
       ) : (
         <>
           <VideoPlayer


### PR DESCRIPTION
### **🚀 Description**
Added Playwright tests for the VideoDetail page and introduced a login test to save authentication state.

#### **📌 Summary**
This PR covers e2e tests for the VideoDetail page and adds a login test to persist authentication for future tests.

#### **🔧 Changes Implemented**
- ✅ Added Playwright tests for VideoDetail page
- ✅ Added login test to save authentication state
- ✅ Extracted SkeletonLoader as a separate component for video player loading skeletons.

#### **🛠️ How It Works?**
1. The login test saves the authenticated state for reuse in other tests.
2. VideoDetail tests check page rendering and navigation behavior.
3. Manual login is required before running tests to ensure valid session.

#### **✅ Checklist Before Merging**
- [ ]  Confirmed login state is saved correctly
- [ ]  Verified VideoDetail tests pass after login

#### **📸 Screenshots (if applicable)**
<img width="1003" height="418" alt="Screenshot 2025-07-16 at 2 33 57 PM" src="https://github.com/user-attachments/assets/9acc66a9-e76a-4b9b-99fc-1e68dd022c0f" />

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/137

#### **📢 Notes for Reviewers**
- First run: `npx playwright test playwright-tests/setup/login.spec.ts --headed`
- Manually login via Google SSO when prompted
- Then, uncomment the storageState line in the Playwright config and run the tests: `storageState: "playwright-tests/storageState.json",`
