### PR TITLE
fix: set default sorting to newest first

### DIFF
--- a/src/hooks/useVideoQueryManager.ts
+++ b/src/hooks/useVideoQueryManager.ts
@@ -30,7 +30,7 @@ export function useVideoQueryManager(searchParams: URLSearchParams) {
       page,
       page_size: 12,
       is_featured: false,
-      ordering: [parsedParams.order],
+      ordering: parsedParams.order ? [parsedParams.order] : ["-event_time"],
       search: parsedParams.search ?? undefined,
       tag: parsedParams.search ? "" : (parsedParams.tag ?? ""),
       playlist: parsedParams.search ? "" : (parsedParams.playlist ?? ""),


### PR DESCRIPTION
### **🚀 Description**
Added default ordering of videos by `-event_time`.

#### **📌 Summary**
This PR ensures videos are sorted by Newest first by default.

#### **🔧 Changes Implemented**
- ✅  Applied default ordering -event_time fallback in useVideoQueryManager

#### **🛠️ How It Works?**
1. If order is in the URL, use it. otherwise, default to -event_time in the query manager.
2. Default order applies even when filters are cleared or changed.

#### **✅ Checklist Before Merging**
- [ ] Tested with and without order param
- [ ] Verified default order is applied correctly

#### **📸 Screenshots (if applicable)**
N/A

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/issue/235

#### **📢 Notes for Reviewers**
Please verify that `-event_time` is applied by default.