### PR TITLE
Enhancement: Changed github action to run based on release instead of…

### DIFF
--- a/.github/workflows/build-and-push-container-image.yml
+++ b/.github/workflows/build-and-push-container-image.yml
@@ -1,9 +1,9 @@
 ---
 name: Build and Push Container Image
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-and-push:
@@ -34,4 +34,4 @@ jobs:
             NEXT_PUBLIC_CLIENT_ID=${{ secrets.NEXT_PUBLIC_CLIENT_ID }}
             NEXT_PUBLIC_GTM_ID=${{ secrets.NEXT_PUBLIC_GTM_ID }}
           push: true
-          tags: ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:${{ github.sha }}, ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:latest
+          tags: ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:${{ github.ref_name }}, ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:latest


### PR DESCRIPTION
### **🚀 Description**
_Changed build actions to adapt release structure like backend_

#### **📌 Summary**
_Changed github action "Build and Push Container Image" to run based on releases instead of pushes to main branch._

#### **🔧 Changes Implemented**
- ✅ _Changed release type from push to published_
- ✅ _Changed Github.sha to github.ref_name to find latest release tag instead of comit hash_

#### **🛠️ How It Works?**
1. _Now we will use Github's own release feature to make releases._
2. _The modified github action will take the latest release tag to make docker images._
3. _We can also manually trigger the action now._

#### **✅ Checklist Before Merging**
- [ ] _Tested all relevant functionalities._
- [ ] _Verified expected behavior on different use cases._
- [ ] _Ensured code follows best practices and security standards._

