### PR TITLE
fix: ensure featured video appears on all relevant pages

### DIFF
--- a/src/hooks/useVideoQueryManager.ts
+++ b/src/hooks/useVideoQueryManager.ts
@@ -29,7 +29,6 @@ export function useVideoQueryManager(searchParams: URLSearchParams) {
       ...defaultParams,
       page,
       page_size: 12,
-      is_featured: false,
       ordering: [parsedParams.order],
       search: parsedParams.search ?? undefined,
       tag: parsedParams.search ? "" : (parsedParams.tag ?? ""),


### PR DESCRIPTION
### **🚀 Description**
Fixes the issue where the featured video was not displaying on pages other than the main videos page.

#### **📌 Summary**
This PR removes an incorrect API filter that excluded featured videos, ensuring they appear consistently across all pages.

#### **🔧 Changes Implemented**
- ✅ Removed `is_featured=false` from apiParams in `useVideoQueryManager` hook.
- ✅ Verified featured videos now show correctly on all relevant pages.

#### **🛠️ How It Works?**
1. Removed is_featured=false from useVideoQueryManager to ensure featured videos appear across all pages.

#### **✅ Checklist Before Merging**
- Tested featured videos visibility on all pages.
- Verified API response includes featured videos.

#### **📸 Screenshots (if applicable)**
_(Add screenshots, videos, or GIFs if necessary.)_

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/208

#### **📢 Notes for Reviewers**
Ensure featured videos appear correctly on all  relevant pages.
