### PR TITLE
feat: add automated deployment trigger to build workflow

### DIFF
--- a/.github/workflows/build-and-push-container-image.yml
+++ b/.github/workflows/build-and-push-container-image.yml
@@ -35,3 +35,30 @@ jobs:
             NEXT_PUBLIC_GTM_ID=${{ secrets.NEXT_PUBLIC_GTM_ID }}
           push: true
           tags: ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:${{ github.ref_name }}, ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:latest
+
+      - name: Create Temporary Deployment Token
+        uses: actions/create-github-app-token@v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_PRIVATE_KEY }}
+          owner: ${{ secrets.GH_TRIGGER_OWNER }}
+          repositories: |
+            ${{ secrets.GH_TRIGGER_REPO }}
+
+      - name: Trigger Frontend Deployment
+        uses: actions/github-script@v7.0.1
+        env:
+          OWNER: ${{ secrets.GH_TRIGGER_OWNER }}
+          REPO: ${{ secrets.GH_TRIGGER_REPO }}
+          WORKFLOW_ID: ${{ secrets.GH_TRIGGER_WORKFLOW_ID }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+              await github.rest.actions.createWorkflowDispatch({
+                owner: process.env.OWNER,
+                repo: process.env.REPO,
+                workflow_id: process.env.WORKFLOW_ID,
+                ref: 'main',
+                inputs: { 'frontend_version': '${{ github.ref_name }}' }
+              });


### PR DESCRIPTION
### **🚀 Description**
This PR implements automated deployment triggering in the CI/CD pipeline to streamline the frontend deployment process after successful container builds.

#### **📌 Summary**  
Adds automated deployment workflow dispatch functionality to the existing `build-and-push-container-image` workflow, enabling seamless deployment triggers after successful container builds.

#### **🔧 Changes Implemented**
- ✅ Added GitHub App token creation step for secure deployment repository access
- ✅ Integrated workflow dispatch mechanism using GitHub Script action
- ✅ Added frontend version parameter passing (branch name) to deployment workflow
- ✅ Configured environment variables for deployment repository targeting

#### **🛠️ How It Works?**
1. After successful container build and push, creates a temporary GitHub App token using configured app credentials
2. Uses the token to authenticate with the target deployment repository
3. Triggers the deployment workflow via workflow dispatch API, passing the current branch name as `frontend_version` input

#### **✅ Checklist Before Merging**
- [ ] Tested all relevant functionalities.
- [x] Verified expected behavior on different use cases.
- [ ] Ensured code follows best practices and security standards.

#### **📸 Screenshots (if applicable)**
_Not applicable for CI/CD workflow changes._

#### **🔗 Related Issues**
_Link to the associated Taiga ticket_
https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/165

#### **📢 Notes for Reviewers**
- Ensure GitHub App credentials (`GH_APP_ID`, `GH_PRIVATE_KEY`) are properly configured in repository secrets
- Verify deployment repository settings (`GH_TRIGGER_OWNER`, `GH_TRIGGER_REPO`, `GH_TRIGGER_WORKFLOW_ID`) are correct
- This change requires the target deployment repository to have a workflow that accepts `frontend_version` input