### PR TITLE
add captions support and view counting

### DIFF
--- a/src/components/VideoPlayer/styles.css
+++ b/src/components/VideoPlayer/styles.css
@@ -14,13 +14,19 @@
   --video-focus-ring-color: var(--focus-color);
   --video-border-radius: 2px;
 
+  --media-cue-font-size: calc(var(--media-height) / 100 * 4.5);
+
   /* 👉 https://vidstack.io/docs/player/components/layouts/default#css-variables for more. */
 
   [data-view-type="video"] {
     aspect-ratio: 16 /9;
   }
 
-  .vds-google-cast-button,.vds-pip-button{
+  [data-preview] .vds-captions {
+    opacity: 1;
+  }
+
+  .vds-google-cast-button,.vds-pip-button {
     display: none;
   }
 

--- a/src/components/VideoPlayer/types.ts
+++ b/src/components/VideoPlayer/types.ts
@@ -1,14 +1,17 @@
 import { MediaCrossOrigin } from "@vidstack/react";
 
 export interface VideoPlayerProps {
+  captionsFile?: string;
   className?: string;
   crossOrigin?: true | MediaCrossOrigin | null;
   height?: string;
   onVideoEnded?: VoidFunction;
+  onWatchThreshold?: () => void;
   playsInline?: boolean;
   posterAlt: string;
   posterSrc: string;
   title: string;
   videoSrc: string;
+  watchThresholdSeconds?: number;
   width?: string;
 }

--- a/src/components/VideoPlayer/videoPlayer.tsx
+++ b/src/components/VideoPlayer/videoPlayer.tsx
@@ -3,7 +3,7 @@
 import React, { FC, useEffect, useRef } from "react";
 
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
-import { MediaPlayer, MediaProvider, useMediaState, Poster, type MediaPlayerInstance, PlayButton } from "@vidstack/react";
+import { MediaPlayer, MediaProvider, useMediaState, Poster, Track, type MediaPlayerInstance, PlayButton } from "@vidstack/react";
 import { defaultLayoutIcons, DefaultVideoLayout } from "@vidstack/react/player/layouts/default";
 import clsx from "clsx";
 import "@vidstack/react/player/styles/default/theme.css";
@@ -13,15 +13,18 @@ import { VideoPlayerProps } from "./types";
 import "./styles.css";
 
 const VideoPlayer: FC<VideoPlayerProps> = ({
+  captionsFile,
   className,
   crossOrigin = true,
   height,
   onVideoEnded,
+  onWatchThreshold,
   playsInline = true,
   posterAlt,
   posterSrc,
   title,
   videoSrc,
+  watchThresholdSeconds = 30,
   width = "70%",
 }) => {
   const player = useRef<MediaPlayerInstance>(null);
@@ -37,6 +40,26 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
 
   const isPaused = useMediaState("paused", player);
 
+  const accumulatedTimeRef = useRef(0);
+  const hasCountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!onWatchThreshold || hasCountedRef.current) return;
+
+    const interval = setInterval(() => {
+      if (!isPaused) {
+        accumulatedTimeRef.current += 1;
+        if (accumulatedTimeRef.current >= watchThresholdSeconds) {
+          hasCountedRef.current = true;
+          onWatchThreshold();
+          clearInterval(interval);
+        }
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isPaused, onWatchThreshold, watchThresholdSeconds]);
+
   return (
     <div style={{ width, height }}>
       <MediaPlayer
@@ -49,6 +72,16 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
       >
         <MediaProvider>
           <Poster className="vds-poster" src={posterSrc} alt={posterAlt} />
+          {captionsFile && (
+            <Track
+              src={captionsFile}
+              kind="subtitles"
+              label="English"
+              language="en"
+              type={captionsFile.split(".").pop()?.toLowerCase() === "srt" ? "srt" : "vtt"}
+              default
+            />
+          )}
         </MediaProvider>
 
         {isPaused && (
@@ -58,7 +91,7 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
         )}
 
         {/* Layouts */}
-        <DefaultVideoLayout icons={defaultLayoutIcons} />
+        <DefaultVideoLayout icons={defaultLayoutIcons} noAudioGain slots={{ playbackMenuLoop: null }} />
       </MediaPlayer>
     </div>
   );

--- a/src/features/VideoDetail/videoDetail.tsx
+++ b/src/features/VideoDetail/videoDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
@@ -19,7 +19,7 @@ import VideoCard from "@/components/VideoCard";
 import VideoPlayer from "@/components/VideoPlayer";
 import { DEFAULT_THUMBNAIL } from "@/constants/constants";
 import useNavigation from "@/hooks/useNavigation";
-import { useEventDetailQuery, useRecommendationQuery } from "@/redux/events/apiSlice";
+import { useEventDetailQuery, useIncrementViewCountMutation, useRecommendationQuery } from "@/redux/events/apiSlice";
 import { selectAccessToken } from "@/redux/login/selectors";
 import { fullName, transformVideoToCardData } from "@/utils/utils";
 
@@ -34,6 +34,9 @@ const VideoDetail = () => {
   const { navigateTo, getPageUrl } = useNavigation();
 
   const [page, setPage] = useState(1);
+  const [displayedViewCount, setDisplayedViewCount] = useState<number | null>(null);
+
+  const [incrementViewCount] = useIncrementViewCountMutation();
 
   const { data: recommendationsData, isFetching: isRecommendationsFetching } = useRecommendationQuery(
     accessToken && videoId ? { id: videoId, page } : skipToken
@@ -52,6 +55,18 @@ const VideoDetail = () => {
       navigateTo("videos");
     }
   }, [error]);
+
+  useEffect(() => {
+    if (data?.view_count !== null && data?.view_count !== undefined) setDisplayedViewCount(data.view_count);
+  }, [data?.view_count]);
+
+  const handleWatchThreshold = useCallback(() => {
+    incrementViewCount(videoId)
+      .unwrap()
+      .then((res) => {
+        setDisplayedViewCount(res.view_count);
+      });
+  }, [videoId, incrementViewCount]);
 
   const dataEvent = data?.event;
   const allRecommendations = recommendationsData?.results ?? [];
@@ -100,6 +115,7 @@ const VideoDetail = () => {
           {data?.video_file && (
             <VideoPlayer
               {...{
+                captionsFile: data?.captions_file,
                 crossOrigin: true,
                 playsInline: true,
                 width: "100%",
@@ -107,6 +123,7 @@ const VideoDetail = () => {
                 videoSrc: data?.video_file ?? "",
                 posterSrc: data?.thumbnail || DEFAULT_THUMBNAIL,
                 posterAlt: data?.event?.title ?? "",
+                onWatchThreshold: handleWatchThreshold,
               }}
             />
           )}
@@ -123,6 +140,11 @@ const VideoDetail = () => {
               <Typography color="textSecondary" component="time" dateTime={dataEvent?.event_time} tabIndex={0}>
                 {format(dataEvent?.event_time ?? "", "MMM dd, yyyy")}
               </Typography>
+              {displayedViewCount !== null && displayedViewCount !== undefined && (
+                <Typography color="textSecondary" variant="bodySmall" component="p" tabIndex={0}>
+                  {displayedViewCount.toLocaleString()} {displayedViewCount === 1 ? "view" : "views"}
+                </Typography>
+              )}
             </StyledDetailSection>
             <StyledNotesSection>
               <Typography variant="h5" component="h2" tabIndex={0}>

--- a/src/models/Events/events.ts
+++ b/src/models/Events/events.ts
@@ -1,4 +1,5 @@
 export interface EventDetail {
+  captions_file?: string;
   duration: number;
   event: Event;
   file_size: number;
@@ -6,6 +7,7 @@ export interface EventDetail {
   thumbnail: string;
   title: string;
   video_file: string;
+  view_count: number;
 }
 
 export interface Tag {
@@ -83,3 +85,29 @@ export type RecommendationParam = {
   page: number;
   page_size?: number;
 };
+
+export interface VideoAssetUploadResponse {
+  id: number;
+  title: string;
+  video_file: string;
+  status: string;
+}
+
+export interface UserSearchResult {
+  id: number;
+  first_name: string;
+  last_name: string;
+  full_name: string;
+  email: string;
+}
+
+export interface EventCreateParams {
+  title: string;
+  description: string;
+  event_time: string;
+  playlists: number[];
+  presenter_ids: number[];
+  video_asset_id: number;
+  thumbnail?: File;
+  tags?: number[];
+}


### PR DESCRIPTION
### 🚀 Description
Add captions support and view counting functionality to the video player and detail page.

#### 📌 Summary
This PR enhances the video experience by adding support for captions (VTT/SRT files) and implementing automatic view count incrementation after 30 seconds of watch time.

#### 🔧 Changes Implemented
- ✅ Added captions file support to VideoPlayer component with Track element for subtitles
- ✅ Implemented view counting logic that increments after 30 seconds of continuous watching
- ✅ Added view count display in video detail page
- ✅ Updated EventDetail model to include captions_file and view_count fields
- ✅ Added CSS styling for captions font size and visibility in preview mode
- ✅ Added new props to VideoPlayer for captions and watch threshold handling

#### 🛠️ How It Works?
1. Captions files are passed as props and rendered using Vidstack's Track component
2. View counting uses an interval to track accumulated watch time, triggering increment when threshold is reached
3. View count is displayed dynamically and updates after incrementation
4. Captions are styled with responsive font sizing and visible in preview mode

#### ✅ Checklist Before Merging
- [ ] Tested captions display with VTT/SRT files
- [ ] Verified view count increments correctly after 30 seconds
- [ ] Ensured view count displays properly in video detail page
- [ ] Confirmed captions styling works across different screen sizes

#### 📸 Screenshots (if applicable)
(Add screenshots showing captions enabled and view count display)

#### 🔗 Related Issues
N/A

#### 📢 Notes for Reviewers
- Check that captions files are properly loaded and displayed
- Verify the 30-second threshold logic for view counting
- Ensure the view count mutation updates the UI correctly
- Test with different video formats and caption file types