### PR TITLE
feat(app): add error boundary and not-found pages

### DIFF
--- a/public/assets/svgs/empty-state.svg
+++ b/public/assets/svgs/empty-state.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="132" height="132" viewBox="0 0 132 132" fill="none">
+  <!-- box body -->
+  <rect x="18" y="52" width="96" height="68" rx="6" fill="#E8EDF5" stroke="#B0BDD0" stroke-width="2"/>
+  <!-- box lid left flap -->
+  <path d="M18 52 L66 68 L66 52 Z" fill="#D0D9E8" stroke="#B0BDD0" stroke-width="2" stroke-linejoin="round"/>
+  <!-- box lid right flap -->
+  <path d="M114 52 L66 68 L66 52 Z" fill="#C4CFDF" stroke="#B0BDD0" stroke-width="2" stroke-linejoin="round"/>
+  <!-- tape strip -->
+  <rect x="56" y="48" width="20" height="10" rx="2" fill="#F5C842" opacity="0.85"/>
+  <!-- magnifying glass handle -->
+  <line x1="90" y1="88" x2="104" y2="102" stroke="#8A97AA" stroke-width="4" stroke-linecap="round"/>
+  <!-- magnifying glass circle -->
+  <circle cx="82" cy="80" r="14" fill="white" stroke="#8A97AA" stroke-width="3"/>
+  <!-- question mark inside lens -->
+  <text x="78" y="86" font-family="sans-serif" font-size="14" font-weight="700" fill="#8A97AA">?</text>
+</svg>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+import * as Sentry from "@sentry/nextjs";
+import { useRouter } from "next/navigation";
+
+import Button from "@/components/Button";
+import EmptyState from "@/components/EmptyState";
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <EmptyState
+      heading="Something went wrong"
+      text="An unexpected error occurred. You can try reloading the page or go back."
+      ctas={[
+        <Button key="back" variant="contained" onClick={() => router.back()}>
+          Go back
+        </Button>,
+        <Button key="reload" variant="contained" color="primary" onClick={reset}>
+          Reload
+        </Button>,
+      ]}
+    />
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+
+import Button from "@/components/Button";
+import EmptyState from "@/components/EmptyState";
+
+export default function NotFound() {
+  return (
+    <EmptyState
+      heading="Page not found"
+      text="The page you're looking for doesn't exist or has been moved."
+      ctas={[
+        <Button key="back" color="secondary" variant="contained" component={Link} href="/videos">
+          Go back
+        </Button>,
+      ]}
+    />
+  );
+}

--- a/src/components/EmptyState/emptyState.tsx
+++ b/src/components/EmptyState/emptyState.tsx
@@ -10,8 +10,8 @@ import { EmptyStateProps } from "./emptyStateType";
 import { ButtonsContainer, Container, Heading, ImageContainer, SVGIconWrapper } from "./styled";
 
 const DEFAULT_IMAGE = {
-  src: "/images/empty-state.svg",
-  alt: "Bee flying out of an empty box",
+  src: "/assets/svgs/empty-state.svg",
+  alt: "Empty box with a magnifying glass",
   width: 132,
   height: 132,
 };


### PR DESCRIPTION
### 🚀 Description
Add App Router error and not-found pages so runtime errors and unknown routes render a friendly, consistent UI instead of the default framework fallbacks.

#### 📌 Summary
This PR introduces a global error boundary (`error.tsx`) that captures exceptions in Sentry and a custom 404 page (`not-found.tsx`). Both reuse the shared `EmptyState` component for a consistent look, backed by a new empty-state illustration.

#### 🔧 Changes Implemented
- ✅ Added `src/app/error.tsx` — client error boundary that reports to Sentry and provides "Go back" and "Reload" recovery actions
- ✅ Added `src/app/not-found.tsx` — custom 404 page with a link back to `/videos`
- ✅ Added `public/assets/svgs/empty-state.svg` — empty box + magnifying glass illustration
- ✅ Updated `EmptyState` default image path and alt text to match the new asset

#### 🛠️ How It Works?
1. When a rendering error is thrown, Next.js mounts `error.tsx`, which calls `Sentry.captureException(error)` on mount and shows recovery CTAs (`reset()` to retry, `router.back()` to navigate away).
2. When a route is not matched, Next.js renders `not-found.tsx`, guiding users back to `/videos`.
3. Both screens render through `EmptyState`, so messaging and visuals stay consistent across error states.

#### ✅ Checklist Before Merging
- [ ] Tested error boundary by triggering a runtime error and confirming Sentry capture
- [ ] Verified the 404 page renders for unknown routes and the back link works
- [ ] Confirmed the new SVG renders correctly across themes/sizes

#### 🔗 Related Issues
https://projects.arbisoft.com/arbisoft/browse/ASP-275/

#### 📢 Notes for Reviewers
- UI change: please verify responsiveness and theme behavior of both pages and the new illustration.
- `error.tsx` is intentionally a Client Component (`"use client"`) as required by Next.js for error boundaries; Sentry capture runs in `useEffect`.
- Default `EmptyState` image moved from `/images/empty-state.svg` to `/assets/svgs/empty-state.svg` — confirm no other references rely on the old path.
