### PR TITLE
fix(filters): add aria heading roles to sort and filter section labels

### DIFF
--- a/src/features/VideosListingPage/DateFilterDropdown.tsx
+++ b/src/features/VideosListingPage/DateFilterDropdown.tsx
@@ -114,7 +114,7 @@ const DateFilterDropdown = ({
           },
         }}
       >
-        <Typography component="li" variant="h6" sx={{ px: 2, py: 1 }} id="sort-section">
+        <Typography component="li" variant="h6" sx={{ px: 2, py: 1 }} id="sort-section" role="heading" aria-level={3}>
           Sort By
         </Typography>
         <MenuItem
@@ -138,7 +138,7 @@ const DateFilterDropdown = ({
 
         <Divider component="li" role="separator" sx={{ my: 1 }} />
 
-        <Typography component="li" variant="h6" sx={{ px: 2, py: 1 }} id="filter-section">
+        <Typography component="li" variant="h6" sx={{ px: 2, py: 1 }} id="filter-section" role="heading" aria-level={3}>
           Filter by
         </Typography>
 


### PR DESCRIPTION
### 🚀 Description
Improve accessibility of the date filter dropdown by correctly marking section labels as ARIA headings.

#### 📌 Summary
The "Sort By" and "Filter by" labels inside `DateFilterDropdown` were rendered as `<li>` elements with no ARIA role, making them invisible as structural headings to screen readers. This PR adds `role="heading"` and `aria-level={3}` to both labels so assistive technologies can announce them as section headings.

#### 🔧 Changes Implemented
- ✅ Added `role="heading" aria-level={3}` to the "Sort By" section label
- ✅ Added `role="heading" aria-level={3}` to the "Filter by" section label

#### 🛠️ How It Works?
1. Both `Typography` components inside the dropdown menu are rendered as `<li>` elements (via `component="li"`), which doesn't carry implicit heading semantics.
2. Adding `role="heading"` overrides the listitem role for screen readers, and `aria-level={3}` communicates the correct heading hierarchy.
3. No visual changes — this is a semantics-only fix.

#### ✅ Checklist Before Merging
- [ ] Verified with a screen reader (VoiceOver / NVDA) that headings are announced correctly inside the dropdown.
- [ ] Confirmed no visual regression in the date filter dropdown.
- [ ] Ensured existing tests still pass.

#### 📸 Screenshots (if applicable)
N/A — no visual changes.

#### 🔗 Related Issues
https://projects.arbisoft.com/arbisoft/browse/ASP-167/

#### 📢 Notes for Reviewers
The only change is two added ARIA attributes on `Typography` nodes that serve as section separators inside the MUI Menu. The `role="presentation"` already on the `Divider` is unaffected. Reviewers may want to spot-check with a browser accessibility tree inspector (e.g. Chrome DevTools → Accessibility panel) to confirm heading levels look correct in context.
