### PR TITLE
ci(sentry): wire build-time vars into image build

### DIFF
--- a/.github/workflows/build-and-push-container-image.yml
+++ b/.github/workflows/build-and-push-container-image.yml
@@ -33,6 +33,11 @@ jobs:
             NEXT_PUBLIC_BASE_URL=${{ secrets.NEXT_PUBLIC_BASE_URL }}
             NEXT_PUBLIC_CLIENT_ID=${{ secrets.NEXT_PUBLIC_CLIENT_ID }}
             NEXT_PUBLIC_GTM_ID=${{ secrets.NEXT_PUBLIC_GTM_ID }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+          secrets: |
+            sentry_auth=${{ secrets.SENTRY_AUTH_TOKEN }}
           push: true
           tags: ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:${{ github.ref_name }}, ${{ secrets.CONTAINER_IMAGE_REPO }}/session-portal-frontend:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Stage 1: Install dependencies
 FROM node:22.14.0-alpine AS deps
 
@@ -14,10 +15,16 @@ FROM node:22.14.0-alpine AS builder
 ARG NEXT_PUBLIC_BASE_URL
 ARG NEXT_PUBLIC_CLIENT_ID
 ARG NEXT_PUBLIC_GTM_ID
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
 
 ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
 ENV NEXT_PUBLIC_CLIENT_ID=${NEXT_PUBLIC_CLIENT_ID}
 ENV NEXT_PUBLIC_GTM_ID=${NEXT_PUBLIC_GTM_ID}
+ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+ENV SENTRY_ORG=${SENTRY_ORG}
+ENV SENTRY_PROJECT=${SENTRY_PROJECT}
 
 WORKDIR /app
 
@@ -27,7 +34,8 @@ COPY --from=deps /app/node_modules ./node_modules
 # Copy application source
 COPY . .
 
-RUN npm run build
+RUN --mount=type=secret,id=sentry_auth,required=false \
+    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth 2>/dev/null || true)" npm run build
 
 # Stage 3: Lightweight runtime image
 FROM node:22.14.0-alpine AS runner


### PR DESCRIPTION
## What
Closes the delivery-pipeline gap left by #165 (Sentry SDK integration): supplies the four Sentry build-time variables to `next build` so the released frontend image is Sentry-instrumented.

## Changes
**Dockerfile**
- `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT` → builder-stage `ARG`/`ENV`, so `next build` inlines the DSN and `withSentryConfig` uploads source maps.
- `SENTRY_AUTH_TOKEN` → BuildKit secret mount (`id=sentry_auth`, `required=false`); never an `ARG`/`ENV`, never in an image layer, `docker history`, or the runtime image.
- Added `# syntax=docker/dockerfile:1` for secret-mount support.

**.github/workflows/build-and-push-container-image.yml**
- Three public vars passed via `build-args` from repo secrets.
- `SENTRY_AUTH_TOKEN` passed via `docker/build-push-action` `secrets:` (`sentry_auth`).

## Required Actions secrets
`NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`. Without the token the build still succeeds (source-map upload skipped).

## Notes
- All four vars are build-time only; none read at runtime.
