### PR TITLE
fix(docker): include root-level sentry configs in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,5 @@ README.md
 *.spec.*
 *.ts
 *.tsx
+!sentry.server.config.ts
+!sentry.edge.config.ts


### PR DESCRIPTION
## Summary
Fixes the failed container image build for release v1.3.2 by re-including the root-level Sentry config files in the Docker build context.

- Failed run: https://github.com/arbisoft/session-portal-frontend/actions/runs/28576157468/job/84725094163
- Failing step: "Build and Push Docker Image" (`npm run build` inside the image)

```
Error: Turbopack build failed with 2 errors:
./src/instrumentation.ts:5:11  Module not found: Can't resolve '../sentry.server.config'
./src/instrumentation.ts:9:11  Module not found: Can't resolve '../sentry.edge.config'
```

## Root cause
- `.dockerignore` lines 19–20 contain blanket `*.ts` / `*.tsx` rules. `.dockerignore` patterns are root-anchored (unlike `.gitignore`), so they exclude top-level files only; `src/` is unaffected.
- The v1.3.2 Sentry integration added the first root-level `.ts` files required by the production build: `sentry.server.config.ts` and `sentry.edge.config.ts`, imported by `src/instrumentation.ts`.
- Both files were excluded from the build context, so module resolution failed during `next build`. Releases ≤ v1.3.1 were unaffected because no root-level `.ts` file was needed at build time.

## Changes
- `.dockerignore`: append negation patterns to re-include the two files:

```
!sentry.server.config.ts
!sentry.edge.config.ts
```

## Verification
- Probe `docker build` copying the two files from the build context: fails on current `main`, succeeds with this change.

## Notes
- Re-running the failed v1.3.2 workflow rebuilds the same commit (`32cbd41`) and fails again; the fix applies from the next release cut after merge.
