### PR TITLE
fix(docker): include next.config.ts in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,4 @@ README.md
 *.tsx
 !sentry.server.config.ts
 !sentry.edge.config.ts
+!next.config.ts


### PR DESCRIPTION
### 🚀 Description
Fix the container release build failing with `"/app/.next/standalone": not found` by re-including `next.config.ts` in the Docker build context.

#### 📌 Summary
`.dockerignore` line 19 (`*.ts`) excludes root-level TypeScript files. When Sentry integration renamed `next.config.js` → `next.config.ts` (`578d5b5`), the config silently fell under this rule. The builder stage then ran `next build` with default config — `output: "standalone"` was never applied, `.next/standalone` was never generated, and the runner stage `COPY` at `Dockerfile:56` failed. Releases v1.3.2 and v1.3.3 are both broken by this (v1.3.2 surfaced it as the missing sentry-config module, fixed in #170; v1.3.3 surfaced the standalone gap).
